### PR TITLE
FLUID-6465: Relocate Nexus repositories to fluid-project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Nexus Demos
 ===========
 
-This repository contains some demos showing usage of the GPII Nexus
+This repository contains some demos showing usage of the Infusion Nexus
 integration technology:
 
 - A music demo
@@ -11,8 +11,8 @@ Getting the demos and installing dependencies
 ---------------------------------------------
 
 ```
-> git clone https://github.com/simonbates/nexus-demos.git
-> cd nexus-demos
+> git clone https://github.com/fluid-project/infusion-nexus-demos.git
+> cd infusion-nexus-demos
 > npm install
 ```
 
@@ -28,12 +28,12 @@ information.
 
 For the Music demo, the base Nexus may be used. It can be found at:
 
-- https://github.com/GPII/nexus
+- https://github.com/fluid-project/infusion-nexus
 
 For the Science lab demo, a Co-Occurrence Engine enabled Nexus is
 required. To run such a Nexus, clone the following repository:
 
-- https://github.com/simonbates/co-occurrence-engine
+- https://github.com/fluid-project/co-occurrence-engine
 
 And run:
 

--- a/docs/NexusOnCHIP.md
+++ b/docs/NexusOnCHIP.md
@@ -164,7 +164,7 @@ Get Nexus and Nexus Demos
 -------------------------
 
     $ git clone https://github.com/GPII/nexus.git
-    $ git clone https://github.com/simonbates/nexus-demos.git
+    $ git clone https://github.com/fluid-project/infusion-nexus-demos.git
 
 Start Nexus at boot with systemd
 --------------------------------

--- a/docs/SenseHatPi3.md
+++ b/docs/SenseHatPi3.md
@@ -93,7 +93,7 @@ Get the Nexus Demos
 -------------------
 
     $ cd ~
-    $ git clone https://github.com/simonbates/nexus-demos.git
+    $ git clone https://github.com/fluid-project/infusion-nexus-demos.git
     $ cd nexus-demos
     $ npm install
 

--- a/music-demo/asterics-zone-controller/index.html
+++ b/music-demo/asterics-zone-controller/index.html
@@ -20,7 +20,7 @@
         <script type="text/javascript" src="../zone-controller/js/mouse-pointer.js"></script>
         <script type="text/javascript" src="../zone-controller/js/zone-controller.js"></script>
         <script type="text/javascript" src="../zone-controller/js/head-tracker-synth.js"></script>
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script type="text/javascript" src="../zone-controller/js/nexusZoneController.js"></script>
 
         <script src="js/nexusAstericsHeadTracker.js"></script>
@@ -56,7 +56,7 @@
         </main>
 
         <script>
-            window.astericsZoneController = gpii.nexusZoneController("body", {
+            window.astericsZoneController = fluid.nexusZoneController("body", {
                 members: {
                     nexusHost: window.location.hostname
                 },

--- a/music-demo/bonang-synth-control/index.html
+++ b/music-demo/bonang-synth-control/index.html
@@ -11,19 +11,19 @@
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/FluidIoC.js"></script>
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/DataBinding.js"></script>
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/FluidView.js"></script>
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script type="text/javascript" src="js/nexusBonangSynthControl.js"></script>
     </head>
     <body>
         <h1>Bonang Synth Control</h1>
 
-        <p id="gpiic-bonang-synth-control">
-            <label>Note: <input class="gpiic-bonang-synth-note" type="number" value="0"></label>
-            <button class="gpiic-bonang-synth-send" type="button">Send</button>
+        <p id="fluidc-bonang-synth-control">
+            <label>Note: <input class="fluidc-bonang-synth-note" type="number" value="0"></label>
+            <button class="fluidc-bonang-synth-send" type="button">Send</button>
         </p>
 
         <script>
-            window.bonangSynthControl = gpii.nexusBonangSynthControl("#gpiic-bonang-synth-control");
+            window.bonangSynthControl = fluid.nexusBonangSynthControl("#fluidc-bonang-synth-control");
         </script>
     </body>
 </html>

--- a/music-demo/bonang-synth-control/js/nexusBonangSynthControl.js
+++ b/music-demo/bonang-synth-control/js/nexusBonangSynthControl.js
@@ -1,11 +1,11 @@
 (function () {
     "use strict";
 
-    fluid.defaults("gpii.nexusBonangSynthControl", {
+    fluid.defaults("fluid.nexusBonangSynthControl", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         selectors: {
-            noteInput: ".gpiic-bonang-synth-note",
-            sendButton: ".gpiic-bonang-synth-send"
+            noteInput: ".fluidc-bonang-synth-note",
+            sendButton: ".fluidc-bonang-synth-send"
         },
         members: {
             nexusPeerComponentPath: "nexus.bonang.control",
@@ -18,7 +18,7 @@
         },
         invokers: {
             sendButtonHandler: {
-                funcName: "gpii.nexusBonangSynthControl.sendButtonHandler",
+                funcName: "fluid.nexusBonangSynthControl.sendButtonHandler",
                 args: [
                     "{that}.applier",
                     "{that}.nexusBoundModelPath",
@@ -35,7 +35,7 @@
         }
     });
 
-    gpii.nexusBonangSynthControl.sendButtonHandler = function (applier, modelPath, noteInput) {
+    fluid.nexusBonangSynthControl.sendButtonHandler = function (applier, modelPath, noteInput) {
         var noteVal = fluid.parseInteger(noteInput.val());
         applier.change(modelPath, noteVal);
     };

--- a/music-demo/bonang-synth/index.html
+++ b/music-demo/bonang-synth/index.html
@@ -20,14 +20,14 @@
         <script src="../../node_modules/flocking/src/ugens/buffer.js"></script>
 
         <script src="js/bonang-synth.js"></script>
-        <script src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script src="js/nexusBonangSynth.js"></script>
     </head>
     <body>
         <h1>Bonang Synth</h1>
 
         <script>
-            window.bonangSynth = gpii.nexusBonangSynth({
+            window.bonangSynth = fluid.nexusBonangSynth({
                 members: {
                     nexusHost: window.location.hostname
                 },

--- a/music-demo/bonang-synth/js/nexusBonangSynth.js
+++ b/music-demo/bonang-synth/js/nexusBonangSynth.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    fluid.defaults("gpii.nexusBonangSynth", {
+    fluid.defaults("fluid.nexusBonangSynth", {
         gradeNames: "gpii.nexusWebSocketBoundComponent",
         members: {
             nexusPeerComponentPath: "nexus.bonang.synth",
@@ -20,10 +20,10 @@
                 type: "fluid.trackerSynth.bonang",
                 options: {
                     model: {
-                        activeNote: "{gpii.nexusBonangSynth}.model.controls.activeNote",
+                        activeNote: "{fluid.nexusBonangSynth}.model.controls.activeNote",
                         inputs: {
                             tremolo: {
-                                freq: "{gpii.nexusBonangSynth}.model.controls.tremoloFreq"
+                                freq: "{fluid.nexusBonangSynth}.model.controls.tremoloFreq"
                             }
                         }
                     }

--- a/music-demo/constructNexusPeers.js
+++ b/music-demo/constructNexusPeers.js
@@ -3,7 +3,7 @@
 var fluid = require("infusion");
 var gpii = fluid.registerNamespace("gpii");
 
-require("gpii-nexus-client");
+require("infusion-nexus-client");
 
 var nexusHost = "localhost";
 var nexusPort = 9081;

--- a/music-demo/device-orientation/index.html
+++ b/music-demo/device-orientation/index.html
@@ -11,18 +11,18 @@
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/FluidIoC.js"></script>
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/DataBinding.js"></script>
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/FluidView.js"></script>
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script type="text/javascript" src="js/nexusOrientationSensor.js"></script>
     </head>
     <body>
         <h1>Orientation Sensor</h1>
 
-        <p id="gpiic-nexusOrientationSensor">
-            <span class="gpiic-display-orientation-values"></span>
+        <p id="fluidc-nexusOrientationSensor">
+            <span class="fluidc-display-orientation-values"></span>
         </p>
 
         <script>
-            window.nexusOrientationSensor = gpii.nexusOrientationSensor("#gpiic-nexusOrientationSensor", {
+            window.nexusOrientationSensor = fluid.nexusOrientationSensor("#fluidc-nexusOrientationSensor", {
                 members: {
                     nexusHost: window.location.hostname
                 }

--- a/music-demo/device-orientation/js/nexusOrientationSensor.js
+++ b/music-demo/device-orientation/js/nexusOrientationSensor.js
@@ -3,10 +3,10 @@
 (function () {
     "use strict";
 
-    fluid.defaults("gpii.nexusOrientationSensor", {
+    fluid.defaults("fluid.nexusOrientationSensor", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         selectors: {
-            displayOrientationValues: ".gpiic-display-orientation-values"
+            displayOrientationValues: ".fluidc-display-orientation-values"
         },
         members: {
             nexusHost: "localhost", // Set to Nexus host
@@ -22,13 +22,13 @@
         },
         modelListeners: {
             orientation: {
-                funcName: "gpii.nexusOrientationSensor.displayValues",
+                funcName: "fluid.nexusOrientationSensor.displayValues",
                 args: ["{change}.value", "{that}.dom.displayOrientationValues"]
             }
         },
         invokers: {
             handleSensorEvent: {
-                funcName: "gpii.nexusOrientationSensor.handleSensorEvent",
+                funcName: "fluid.nexusOrientationSensor.handleSensorEvent",
                 args: [
                     "{that}",
                     "{that}.applier",
@@ -39,13 +39,13 @@
         },
         listeners: {
             "onCreate.loadSensorDriver": {
-                funcName: "gpii.nexusOrientationSensor.loadSensorDriver",
+                funcName: "fluid.nexusOrientationSensor.loadSensorDriver",
                 args: ["{that}.handleSensorEvent"]
             }
         }
     });
 
-    gpii.nexusOrientationSensor.loadSensorDriver = function (eventHandler) {
+    fluid.nexusOrientationSensor.loadSensorDriver = function (eventHandler) {
         var app = new SensorAPI();
         app.loadDriver("../../node_modules/sensorapijs/driver/deviceOrientation.js");
         app.onDeviceAdded(function(device) {
@@ -53,7 +53,7 @@
         });
     };
 
-    gpii.nexusOrientationSensor.handleSensorEvent = function (that, applier, modelPath, eventData) {
+    fluid.nexusOrientationSensor.handleSensorEvent = function (that, applier, modelPath, eventData) {
         var now = Date.now();
         if (now > that.lastUpdated + that.minimumUpdatePeriodMs) {
             that.lastUpdated = now;
@@ -67,7 +67,7 @@
         }
     };
 
-    gpii.nexusOrientationSensor.displayValues = function (data, elem) {
+    fluid.nexusOrientationSensor.displayValues = function (data, elem) {
         elem.text(JSON.stringify(data));
     };
 

--- a/music-demo/piano-controller/css/pianoController.css
+++ b/music-demo/piano-controller/css/pianoController.css
@@ -8,6 +8,6 @@
     border-bottom-color: black !important;
 }
 
-#piano li.gpii-nexusPianoController-highlighted-key {
+#piano li.fluid-nexusPianoController-highlighted-key {
     border-bottom-color: rgb(255, 220, 0) !important;
 }

--- a/music-demo/piano-controller/index.html
+++ b/music-demo/piano-controller/index.html
@@ -20,7 +20,7 @@
         <script type="text/javascript" src="../../node_modules/flocking/src/core.js"></script>
         <script src="../../node_modules/qwerty-hancock/dist/qwerty-hancock.js"></script>
 
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script src="js/pianoController.js"></script>
     </head>
     <body>
@@ -28,7 +28,7 @@
             <div id="piano"></div>
         </main>
         <script>
-            window.piano = gpii.nexusPianoController("#piano", {
+            window.piano = fluid.nexusPianoController("#piano", {
                 members: {
                     nexusHost: window.location.hostname
                 },

--- a/music-demo/piano-controller/js/pianoController.js
+++ b/music-demo/piano-controller/js/pianoController.js
@@ -110,7 +110,7 @@
         }
     });
 
-    fluid.defaults("gpii.nexusPianoController", {
+    fluid.defaults("fluid.nexusPianoController", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "flock.ui.modelKeyboard"],
 
         highlightKeys: [
@@ -133,7 +133,7 @@
         listeners: {
             onCreate: [
                 {
-                    funcName: "gpii.nexusPianoController.highlightKeys",
+                    funcName: "fluid.nexusPianoController.highlightKeys",
                     args: ["{that}.container", "{that}.options"],
                     priority: "last"
                 }
@@ -141,11 +141,11 @@
         },
 
         styles: {
-            highlightedKey: "gpii-nexusPianoController-highlighted-key"
+            highlightedKey: "fluid-nexusPianoController-highlighted-key"
         }
     });
 
-    gpii.nexusPianoController.highlightKeys = function (container, options) {
+    fluid.nexusPianoController.highlightKeys = function (container, options) {
         fluid.each(options.highlightKeys, function (key) {
             container.find("[id=" + key + "]").addClass(options.styles.highlightedKey);
         });

--- a/music-demo/zone-controller/index.html
+++ b/music-demo/zone-controller/index.html
@@ -20,7 +20,7 @@
         <script type="text/javascript" src="js/mouse-pointer.js"></script>
         <script type="text/javascript" src="js/zone-controller.js"></script>
         <script type="text/javascript" src="js/head-tracker-synth.js"></script>
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script type="text/javascript" src="js/nexusZoneController.js"></script>
     </head>
     <body>
@@ -54,7 +54,7 @@
         </main>
 
         <script>
-            window.zoneController = gpii.nexusZoneController("body", {
+            window.zoneController = fluid.nexusZoneController("body", {
                 members: {
                     nexusHost: window.location.hostname
                 }

--- a/music-demo/zone-controller/js/nexusZoneController.js
+++ b/music-demo/zone-controller/js/nexusZoneController.js
@@ -1,7 +1,7 @@
 (function () {
     "use strict";
 
-    fluid.defaults("gpii.nexusZoneController", {
+    fluid.defaults("fluid.nexusZoneController", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         members: {
             nexusPeerComponentPath: "nexus.bonang.zoneController",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-    "name": "gpii-nexus-demos",
+    "name": "infusion-nexus-demos",
     "version": "0.1.0",
     "license": "BSD-3-Clause",
-    "author": "GPII",
+    "author": "fluid-project",
     "repository": {
         "type": "git",
-        "url": "https://github.com/simonbates/nexus-demos.git"
+        "url": "https://github.com/fluid-project/infusion-nexus-demos.git"
     },
     "dependencies": {
         "commander": "2.9.0",
@@ -14,7 +14,7 @@
         "grunt-contrib-jshint": "1.0.0",
         "grunt-jsonlint": "1.0.7",
         "infusion": "3.0.0-dev.20170727T201856Z.8c48d077a",
-        "gpii-nexus-client": "simonbates/nexus-client",
+        "infusion-nexus-client": "fluid-project/infusion-nexus-client#f330691bb1603160e5139bb6fb783634174fea6f",
         "nexus-science-lab-synths": "waharnum/nexus-science-lab-synths",
         "node-static": "0.7.10",
         "p5": "0.4.24",

--- a/science-lab/ConstructScienceLabPeersAndRecipes.js
+++ b/science-lab/ConstructScienceLabPeersAndRecipes.js
@@ -3,7 +3,7 @@
 var fluid = require("infusion");
 var gpii = fluid.registerNamespace("gpii");
 
-require("gpii-nexus-client");
+require("infusion-nexus-client");
 
 var nexusHost = "localhost";
 var nexusPort = 9081;
@@ -13,7 +13,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.fakeSensor",
+            "fluid.nexus.fakeSensor",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -26,7 +26,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.fakeSensorPH",
+            "fluid.nexus.fakeSensorPH",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -39,7 +39,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.fakeSensorTemperature",
+            "fluid.nexus.fakeSensorTemperature",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -52,7 +52,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.atlasScientificDriver.phSensor",
+            "fluid.nexus.atlasScientificDriver.phSensor",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -65,7 +65,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.atlasScientificDriver.ecSensor",
+            "fluid.nexus.atlasScientificDriver.ecSensor",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -78,7 +78,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.rpiSenseHatDriver.tempSensor1",
+            "fluid.nexus.rpiSenseHatDriver.tempSensor1",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -91,7 +91,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.rpiSenseHatDriver.tempSensor2",
+            "fluid.nexus.rpiSenseHatDriver.tempSensor2",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -104,7 +104,7 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.collector",
+            "fluid.nexus.scienceLab.collector",
             {
                 gradeNames: [ "fluid.modelComponent" ],
                 model: {
@@ -117,9 +117,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendFakeSensor",
+            "fluid.nexus.scienceLab.sendFakeSensor",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     fakeSensor: null,
                     collector: null
@@ -151,9 +151,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendfakeSensorPH",
+            "fluid.nexus.scienceLab.sendfakeSensorPH",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     fakeSensorPH: null,
                     collector: null
@@ -185,9 +185,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendfakeSensorTemperature",
+            "fluid.nexus.scienceLab.sendfakeSensorTemperature",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     fakeSensorTemperature: null,
                     collector: null
@@ -219,9 +219,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendPhSensor",
+            "fluid.nexus.scienceLab.sendPhSensor",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     phSensor: null,
                     collector: null
@@ -253,9 +253,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendEcSensor",
+            "fluid.nexus.scienceLab.sendEcSensor",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     ecSensor: null,
                     collector: null
@@ -287,9 +287,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendRpiTempSensor1",
+            "fluid.nexus.scienceLab.sendRpiTempSensor1",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     tempSensor: null,
                     collector: null
@@ -321,9 +321,9 @@ fluid.promise.sequence([
         return gpii.writeNexusDefaults(
             nexusHost,
             nexusPort,
-            "gpii.nexus.scienceLab.sendRpiTempSensor2",
+            "fluid.nexus.scienceLab.sendRpiTempSensor2",
             {
-                gradeNames: [ "gpii.nexus.recipeProduct" ],
+                gradeNames: [ "fluid.nexus.recipeProduct" ],
                 componentPaths: {
                     tempSensor: null,
                     collector: null
@@ -353,180 +353,180 @@ fluid.promise.sequence([
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "scienceLabCollector", {
-            type: "gpii.nexus.scienceLab.collector"
+            type: "fluid.nexus.scienceLab.collector"
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendFakeSensor", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensor: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.fakeSensor"
+                        gradeName: "fluid.nexus.fakeSensor"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendFakeSensor",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendFakeSensor"
+                    type: "fluid.nexus.scienceLab.sendFakeSensor"
                 }
             }
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorPH", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensorPH: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.fakeSensorPH"
+                        gradeName: "fluid.nexus.fakeSensorPH"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendfakeSensorPH",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendfakeSensorPH"
+                    type: "fluid.nexus.scienceLab.sendfakeSensorPH"
                 }
             }
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendfakeSensorTemperature", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 fakeSensorTemperature: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.fakeSensorTemperature"
+                        gradeName: "fluid.nexus.fakeSensorTemperature"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendfakeSensorTemperature",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendfakeSensorTemperature"
+                    type: "fluid.nexus.scienceLab.sendfakeSensorTemperature"
                 }
             }
         });
     },    
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendPhSensor", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 phSensor: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.atlasScientificDriver.phSensor"
+                        gradeName: "fluid.nexus.atlasScientificDriver.phSensor"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendPhSensor",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendPhSensor"
+                    type: "fluid.nexus.scienceLab.sendPhSensor"
                 }
             }
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendEcSensor", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 ecSensor: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.atlasScientificDriver.ecSensor"
+                        gradeName: "fluid.nexus.atlasScientificDriver.ecSensor"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendEcSensor",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendEcSensor"
+                    type: "fluid.nexus.scienceLab.sendEcSensor"
                 }
             }
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor1", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 tempSensor: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.rpiSenseHatDriver.tempSensor1"
+                        gradeName: "fluid.nexus.rpiSenseHatDriver.tempSensor1"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendRpiTempSensor1",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendRpiTempSensor1"
+                    type: "fluid.nexus.scienceLab.sendRpiTempSensor1"
                 }
             }
         });
     },
     function () {
         return gpii.constructNexusPeer(nexusHost, nexusPort, "recipes.sendRpiTempSensor2", {
-            type: "gpii.nexus.recipe",
+            type: "fluid.nexus.recipe",
             reactants: {
                 tempSensor: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.rpiSenseHatDriver.tempSensor2"
+                        gradeName: "fluid.nexus.rpiSenseHatDriver.tempSensor2"
                     }
                 },
                 collector: {
                     match: {
                         type: "gradeMatcher",
-                        gradeName: "gpii.nexus.scienceLab.collector"
+                        gradeName: "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             product: {
                 path: "sendRpiTempSensor2",
                 options: {
-                    type: "gpii.nexus.scienceLab.sendRpiTempSensor2"
+                    type: "fluid.nexus.scienceLab.sendRpiTempSensor2"
                 }
             }
         });

--- a/science-lab/FakeSensor.js
+++ b/science-lab/FakeSensor.js
@@ -1,14 +1,13 @@
 "use strict";
 
-var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii");
+var fluid = require("infusion");
 
-require("gpii-nexus-client");
+require("infusion-nexus-client");
 
 var nexusHost = "localhost";
 var nexusPort = 9081;
 
-fluid.defaults("gpii.nexus.fakeSensor", {
+fluid.defaults("fluid.nexus.fakeSensor", {
     gradeNames: ["gpii.nexusWebSocketBoundComponent"],
     model: {
         fakeSensorConfig: {
@@ -24,27 +23,27 @@ fluid.defaults("gpii.nexus.fakeSensor", {
     },
     invokers: {
         "update": {
-            "funcName": "gpii.nexus.fakeSensor.update",
+            "funcName": "fluid.nexus.fakeSensor.update",
             "args": "{that}"
         }
     },
     listeners: {
         "onErrorConstructingPeer.exitProcess": {
-            funcName: "gpii.nexus.fakeSensor.logErrorAndExit",
+            funcName: "fluid.nexus.fakeSensor.logErrorAndExit",
             args: ["{arguments}.0"]
         },
         "onPeerDestroyed.exitProcess": {
-            funcName: "gpii.nexus.fakeSensor.exitProcess"
+            funcName: "fluid.nexus.fakeSensor.exitProcess"
         }
     }
 });
 
-fluid.defaults("gpii.nexus.fakeSensor.sinValue", {
-    gradeNames: ["gpii.nexus.fakeSensor"],
+fluid.defaults("fluid.nexus.fakeSensor.sinValue", {
+    gradeNames: ["fluid.nexus.fakeSensor"],
     members: {
         nexusPeerComponentPath: "fakeSensor",
         nexusPeerComponentOptions: {
-            type: "gpii.nexus.fakeSensor"
+            type: "fluid.nexus.fakeSensor"
         }
     },
     model: {
@@ -60,18 +59,18 @@ fluid.defaults("gpii.nexus.fakeSensor.sinValue", {
     },
     invokers: {
         "getFakeSensorValue": {
-            "funcName": "gpii.nexus.fakeSensor.getFakeSensorValueSin",
+            "funcName": "fluid.nexus.fakeSensor.getFakeSensorValueSin",
             "args": ["{that}"]
         }
     }
 });
 
-fluid.defaults("gpii.nexus.fakeSensor.pHValue", {
-    gradeNames: ["gpii.nexus.fakeSensor"],
+fluid.defaults("fluid.nexus.fakeSensor.pHValue", {
+    gradeNames: ["fluid.nexus.fakeSensor"],
     members: {
         nexusPeerComponentPath: "fakeSensorPH",
         nexusPeerComponentOptions: {
-            type: "gpii.nexus.fakeSensorPH"
+            type: "fluid.nexus.fakeSensorPH"
         }
     },
     model: {
@@ -87,18 +86,18 @@ fluid.defaults("gpii.nexus.fakeSensor.pHValue", {
     },
     invokers: {
         "getFakeSensorValue": {
-            "funcName": "gpii.nexus.fakeSensor.getFakeSensorValuePH"
+            "funcName": "fluid.nexus.fakeSensor.getFakeSensorValuePH"
         }
     }
 });
 
 
-fluid.defaults("gpii.nexus.fakeSensor.temperature", {
-    gradeNames: ["gpii.nexus.fakeSensor"],
+fluid.defaults("fluid.nexus.fakeSensor.temperature", {
+    gradeNames: ["fluid.nexus.fakeSensor"],
     members: {
         nexusPeerComponentPath: "fakeSensorTemperature",
         nexusPeerComponentOptions: {
-            type: "gpii.nexus.fakeSensorTemperature"
+            type: "fluid.nexus.fakeSensorTemperature"
         }
     },
     model: {
@@ -114,60 +113,60 @@ fluid.defaults("gpii.nexus.fakeSensor.temperature", {
     },
     invokers: {
         "getFakeSensorValue": {
-            "funcName": "gpii.nexus.fakeSensor.getFakeSensorValueTemperature"
+            "funcName": "fluid.nexus.fakeSensor.getFakeSensorValueTemperature"
         }
     }
 });
 
-gpii.nexus.fakeSensor.logErrorAndExit = function (error) {
+fluid.nexus.fakeSensor.logErrorAndExit = function (error) {
     console.log(error.message);
     process.exit();
 };
 
-gpii.nexus.fakeSensor.exitProcess = function () {
+fluid.nexus.fakeSensor.exitProcess = function () {
     process.exit();
 };
 
-gpii.nexus.fakeSensor.update = function (that) {
+fluid.nexus.fakeSensor.update = function (that) {
     var nextValue = that.getFakeSensorValue();
     console.log(that.model.sensorData.name + ": " + nextValue);
     that.applier.change("sensorData.value", nextValue);
     setTimeout(function () {
-        gpii.nexus.fakeSensor.update(that);
+        fluid.nexus.fakeSensor.update(that);
     }, that.model.fakeSensorConfig.updateDelayMs);
 };
 
 // A fairly even sin-based sensor value that moves between -1 and 1
 // Calculates the sin period based on the update frequency
-gpii.nexus.fakeSensor.getFakeSensorValueSin = function (that) {
+fluid.nexus.fakeSensor.getFakeSensorValueSin = function (that) {
     var sinPeriodMs = that.model.fakeSensorConfig.updateDelayMs * 10;
     return Math.sin((new Date().getTime() % sinPeriodMs) * Math.PI * 2 / sinPeriodMs);
 };
 
 // a pH sensor type value between 0 and 14
-gpii.nexus.fakeSensor.getFakeSensorValuePH = function () {
-    return gpii.nexus.fakeSensor.randomFloat(0,14);
+fluid.nexus.fakeSensor.getFakeSensorValuePH = function () {
+    return fluid.nexus.fakeSensor.randomFloat(0,14);
 };
 
-gpii.nexus.fakeSensor.getFakeSensorValueTemperature = function () {
-    return gpii.nexus.fakeSensor.randomFloat(10,40);
+fluid.nexus.fakeSensor.getFakeSensorValueTemperature = function () {
+    return fluid.nexus.fakeSensor.randomFloat(10,40);
 };
 
-gpii.nexus.fakeSensor.randomInt = function(min, max) {
+fluid.nexus.fakeSensor.randomInt = function(min, max) {
     min = Math.ceil(min);
     max = Math.floor(max);
     return Math.floor(Math.random() * (max - min)) + min;
 };
 
-gpii.nexus.fakeSensor.randomFloat = function(min, max) {
+fluid.nexus.fakeSensor.randomFloat = function(min, max) {
     return Math.random() * (max - min) + min;
 };
 
-var fakeSensor = gpii.nexus.fakeSensor.sinValue();
+var fakeSensor = fluid.nexus.fakeSensor.sinValue();
 
-var fakeSensorPH = gpii.nexus.fakeSensor.pHValue();
+var fakeSensorPH = fluid.nexus.fakeSensor.pHValue();
 
-var fakeSensorTemperature = gpii.nexus.fakeSensor.temperature();
+var fakeSensorTemperature = fluid.nexus.fakeSensor.temperature();
 
 process.on("SIGINT", function () {
     fakeSensor.destroyNexusPeerComponent();

--- a/science-lab/ScienceLab.json
+++ b/science-lab/ScienceLab.json
@@ -1,6 +1,6 @@
 {
     "defaults": {
-        "gpii.nexus.fakeSensor": {
+        "fluid.nexus.fakeSensor": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -8,7 +8,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.atlasScientificDriver.phSensor": {
+        "fluid.nexus.atlasScientificDriver.phSensor": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -16,7 +16,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.atlasScientificDriver.ecSensor": {
+        "fluid.nexus.atlasScientificDriver.ecSensor": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -24,7 +24,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.rpiSenseHatDriver.tempSensor1": {
+        "fluid.nexus.rpiSenseHatDriver.tempSensor1": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -32,7 +32,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.rpiSenseHatDriver.tempSensor2": {
+        "fluid.nexus.rpiSenseHatDriver.tempSensor2": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -40,7 +40,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.scienceLab.collector": {
+        "fluid.nexus.scienceLab.collector": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -48,9 +48,9 @@
                 "sensors": {}
             }
         },
-        "gpii.nexus.scienceLab.sendFakeSensor": {
+        "fluid.nexus.scienceLab.sendFakeSensor": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "fakeSensor": null,
@@ -81,9 +81,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.sendPhSensor": {
+        "fluid.nexus.scienceLab.sendPhSensor": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "phSensor": null,
@@ -114,9 +114,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.sendEcSensor": {
+        "fluid.nexus.scienceLab.sendEcSensor": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "ecSensor": null,
@@ -147,9 +147,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.sendRpiTempSensor1": {
+        "fluid.nexus.scienceLab.sendRpiTempSensor1": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "tempSensor": null,
@@ -180,9 +180,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.sendRpiTempSensor2": {
+        "fluid.nexus.scienceLab.sendRpiTempSensor2": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "tempSensor": null,
@@ -216,120 +216,120 @@
     },
     "components": {
         "scienceLabCollector": {
-            "type": "gpii.nexus.scienceLab.collector"
+            "type": "fluid.nexus.scienceLab.collector"
         },
         "recipes.sendFakeSensor": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "fakeSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.fakeSensor"
+                        "gradeName": "fluid.nexus.fakeSensor"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendFakeSensor",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendFakeSensor"
+                    "type": "fluid.nexus.scienceLab.sendFakeSensor"
                 }
             }
         },
         "recipes.sendPhSensor": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "phSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.atlasScientificDriver.phSensor"
+                        "gradeName": "fluid.nexus.atlasScientificDriver.phSensor"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendPhSensor",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendPhSensor"
+                    "type": "fluid.nexus.scienceLab.sendPhSensor"
                 }
             }
         },
         "recipes.sendEcSensor": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "ecSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.atlasScientificDriver.ecSensor"
+                        "gradeName": "fluid.nexus.atlasScientificDriver.ecSensor"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendEcSensor",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendEcSensor"
+                    "type": "fluid.nexus.scienceLab.sendEcSensor"
                 }
             }
         },
         "recipes.sendRpiTempSensor1": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "tempSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor1"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor1"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendRpiTempSensor1",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendRpiTempSensor1"
+                    "type": "fluid.nexus.scienceLab.sendRpiTempSensor1"
                 }
             }
         },
         "recipes.sendRpiTempSensor2": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "tempSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor2"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor2"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendRpiTempSensor2",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendRpiTempSensor2"
+                    "type": "fluid.nexus.scienceLab.sendRpiTempSensor2"
                 }
             }
         }

--- a/science-lab/atlas-scientific-driver/AtlasScientificDriver.js
+++ b/science-lab/atlas-scientific-driver/AtlasScientificDriver.js
@@ -1,10 +1,9 @@
 "use strict";
 
 var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii"),
     SerialPort = require("serialport");
 
-fluid.defaults("gpii.nexus.atlasScientificConnection", {
+fluid.defaults("fluid.nexus.atlasScientificConnection", {
     gradeNames: "fluid.component",
 
     devicePath: null, // To be provided by user
@@ -17,10 +16,10 @@ fluid.defaults("gpii.nexus.atlasScientificConnection", {
     },
 
     members: {
-        serialPortParser: "@expand:gpii.nexus.atlasScientificConnection.constructReadlineCrParser()",
+        serialPortParser: "@expand:fluid.nexus.atlasScientificConnection.constructReadlineCrParser()",
         serialPort: {
             expander: {
-                funcName: "gpii.nexus.atlasScientificConnection.constructSerialPort",
+                funcName: "fluid.nexus.atlasScientificConnection.constructSerialPort",
                 args: [
                     "{that}.options.devicePath",
                     "{that}.options.serialPortOptions",
@@ -39,7 +38,7 @@ fluid.defaults("gpii.nexus.atlasScientificConnection", {
             args: ["{that}.openCallback"]
         },
         openCallback: {
-            funcName: "gpii.nexus.atlasScientificConnection.openCallback",
+            funcName: "fluid.nexus.atlasScientificConnection.openCallback",
             args: [
                 "{arguments}.0", // Error
                 "{that}.events.onStarted",
@@ -65,7 +64,7 @@ fluid.defaults("gpii.nexus.atlasScientificConnection", {
 
     listeners: {
         "onData.parseResponse": {
-            listener: "gpii.nexus.atlasScientificConnection.parseResponse",
+            listener: "fluid.nexus.atlasScientificConnection.parseResponse",
             args: [
                 "{that}",
                 "{arguments}.0" // Response
@@ -74,11 +73,11 @@ fluid.defaults("gpii.nexus.atlasScientificConnection", {
     }
 });
 
-gpii.nexus.atlasScientificConnection.constructReadlineCrParser = function () {
+fluid.nexus.atlasScientificConnection.constructReadlineCrParser = function () {
     return SerialPort.parsers.readline("\r");
 };
 
-gpii.nexus.atlasScientificConnection.constructSerialPort = function (devicePath, serialPortOptions, serialPortParser, onDataEvent, onCloseEvent) {
+fluid.nexus.atlasScientificConnection.constructSerialPort = function (devicePath, serialPortOptions, serialPortParser, onDataEvent, onCloseEvent) {
 
     var options = fluid.extend({}, serialPortOptions);
     options.parser = serialPortParser;
@@ -96,7 +95,7 @@ gpii.nexus.atlasScientificConnection.constructSerialPort = function (devicePath,
     return port;
 };
 
-gpii.nexus.atlasScientificConnection.openCallback = function (error, successEvent, errorEvent) {
+fluid.nexus.atlasScientificConnection.openCallback = function (error, successEvent, errorEvent) {
     if (error) {
         errorEvent.fire(error);
     } else {
@@ -104,7 +103,7 @@ gpii.nexus.atlasScientificConnection.openCallback = function (error, successEven
     }
 };
 
-gpii.nexus.atlasScientificConnection.parseResponse = function (that, response) {
+fluid.nexus.atlasScientificConnection.parseResponse = function (that, response) {
     if (/^\d/.test(response)) {
         // Response starts with a digit, parse as a reading
         that.events.onReading.fire(fluid.transform(response.split(","), parseFloat));
@@ -120,7 +119,7 @@ gpii.nexus.atlasScientificConnection.parseResponse = function (that, response) {
     }
 };
 
-fluid.defaults("gpii.nexus.atlasScientificDriver", {
+fluid.defaults("fluid.nexus.atlasScientificDriver", {
     gradeNames: "fluid.modelComponent",
 
     devicePath: null, // To be provided by user
@@ -135,7 +134,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
             rangeMax: 20000,
             nexusPeerComponentPath: "ecSensor",
             nexusPeerComponentOptions: {
-                type: "gpii.nexus.atlasScientificDriver.ecSensor"
+                type: "fluid.nexus.atlasScientificDriver.ecSensor"
             }
         },
         "pH": {
@@ -145,14 +144,14 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
             rangeMax: 14,
             nexusPeerComponentPath: "phSensor",
             nexusPeerComponentOptions: {
-                type: "gpii.nexus.atlasScientificDriver.phSensor"
+                type: "fluid.nexus.atlasScientificDriver.phSensor"
             }
         }
     },
 
     components: {
         atlasScientificConnection: {
-            type: "gpii.nexus.atlasScientificConnection",
+            type: "fluid.nexus.atlasScientificConnection",
             options: {
                 devicePath: "{atlasScientificDriver}.options.devicePath",
                 events: {
@@ -186,7 +185,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                     nexusPort: "{atlasScientificDriver}.options.nexusPort",
                     nexusPeerComponentPath: {
                         expander: {
-                            func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                            func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                             args: [
                                 "{atlasScientificDriver}.options.circuitTypes",
                                 "{that}.options.circuitType",
@@ -196,7 +195,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                     },
                     nexusPeerComponentOptions: {
                         expander: {
-                            func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                            func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                             args: [
                                 "{atlasScientificDriver}.options.circuitTypes",
                                 "{that}.options.circuitType",
@@ -212,7 +211,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                     sensorData: {
                         name: {
                             expander: {
-                                func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                                func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                                 args: [
                                     "{atlasScientificDriver}.options.circuitTypes",
                                     "{that}.options.circuitType",
@@ -222,7 +221,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                         },
                         units: {
                             expander: {
-                                func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                                func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                                 args: [
                                     "{atlasScientificDriver}.options.circuitTypes",
                                     "{that}.options.circuitType",
@@ -232,7 +231,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                         },
                         rangeMin: {
                             expander: {
-                                func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                                func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                                 args: [
                                     "{atlasScientificDriver}.options.circuitTypes",
                                     "{that}.options.circuitType",
@@ -242,7 +241,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                         },
                         rangeMax: {
                             expander: {
-                                func: "gpii.nexus.atlasScientificDriver.lookupCircuitData",
+                                func: "fluid.nexus.atlasScientificDriver.lookupCircuitData",
                                 args: [
                                     "{atlasScientificDriver}.options.circuitTypes",
                                     "{that}.options.circuitType",
@@ -259,7 +258,7 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
                 },
                 listeners: {
                     "{atlasScientificConnection}.events.onReading": {
-                        listener: "gpii.nexus.atlasScientificDriver.updateModelSensorValue",
+                        listener: "fluid.nexus.atlasScientificDriver.updateModelSensorValue",
                         args: [
                             "{that}",
                             "{arguments}.0" // Sensor reading
@@ -287,11 +286,11 @@ fluid.defaults("gpii.nexus.atlasScientificDriver", {
 
 });
 
-gpii.nexus.atlasScientificDriver.lookupCircuitData = function (circuitTypes, deviceType, key) {
+fluid.nexus.atlasScientificDriver.lookupCircuitData = function (circuitTypes, deviceType, key) {
     return circuitTypes[deviceType][key];
 };
 
-gpii.nexus.atlasScientificDriver.updateModelSensorValue = function (nexusBinding, sensorReading) {
+fluid.nexus.atlasScientificDriver.updateModelSensorValue = function (nexusBinding, sensorReading) {
     // Use the first value from the sensor reading
     //
     // For more information, see the Atlas Scientific circuit

--- a/science-lab/atlas-scientific-driver/RunAtlasScientificDriver.js
+++ b/science-lab/atlas-scientific-driver/RunAtlasScientificDriver.js
@@ -1,9 +1,8 @@
 "use strict";
 
-var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii");
+var fluid = require("infusion");
 
-require("gpii-nexus-client");
+require("infusion-nexus-client");
 require("./AtlasScientificDriver.js");
 
 var program = require("commander");
@@ -20,22 +19,22 @@ if (program.device) {
     devicePath = program.device;
 }
 
-gpii.nexus.atlasScientificDriver.logErrorAndExit = function (error) {
+fluid.nexus.atlasScientificDriver.logErrorAndExit = function (error) {
     console.log(error.message);
     process.exit();
 };
 
-var driver = gpii.nexus.atlasScientificDriver({
+var driver = fluid.nexus.atlasScientificDriver({
     devicePath: devicePath,
     nexusHost: nexusHost,
     nexusPort: nexusPort,
     listeners: {
         "onErrorConnectingToSensor.exitProcess": {
-            funcName: "gpii.nexus.atlasScientificDriver.logErrorAndExit",
+            funcName: "fluid.nexus.atlasScientificDriver.logErrorAndExit",
             args: ["{arguments}.0"]
         },
         "onErrorConstructingPeer.exitProcess": {
-            funcName: "gpii.nexus.atlasScientificDriver.logErrorAndExit",
+            funcName: "fluid.nexus.atlasScientificDriver.logErrorAndExit",
             args: ["{arguments}.0"]
         },
         "onNexusPeerComponentDestroyed.exitProcess": {

--- a/science-lab/dashboard/index.html
+++ b/science-lab/dashboard/index.html
@@ -16,14 +16,14 @@
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/ModelTransformation.js"></script>
         <script type="text/javascript" src="../../node_modules/infusion/src/framework/core/js/ModelTransformationTransforms.js"></script>
 
-        <script type="text/javascript" src="../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
         <script type="text/javascript" src="js/NexusScienceLabDashboard.js"></script>
     </head>
     <body>
         <h1 class="fl-nexus-science-lab-hidden">Dashboard</h1>
         <div id="dashboard" class="fl-nexus-science-lab-dashboard"></div>
         <script>
-            window.scienceLabDashboard = gpii.nexusScienceLabDashboard("#dashboard", {
+            window.scienceLabDashboard = fluid.nexusScienceLabDashboard("#dashboard", {
                 members: {
                     nexusHost: window.location.hostname
                 }

--- a/science-lab/dashboard/js/NexusScienceLabDashboard.js
+++ b/science-lab/dashboard/js/NexusScienceLabDashboard.js
@@ -1,11 +1,9 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
-
     // TODO: Add ARIA live region markup?
 
-    fluid.defaults("gpii.nexusScienceLabDashboard", {
+    fluid.defaults("fluid.nexusScienceLabDashboard", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         numberLocale: "en",
         maximumFractionDigits: 2,
@@ -30,13 +28,13 @@
         },
         modelListeners: {
             sensors: {
-                funcName: "gpii.nexusScienceLabDashboard.updateDashboard",
+                funcName: "fluid.nexusScienceLabDashboard.updateDashboard",
                 args: ["{that}", "{change}.value"]
             }
         }
     });
 
-    gpii.nexusScienceLabDashboard.updateDashboard = function (that, sensors) {
+    fluid.nexusScienceLabDashboard.updateDashboard = function (that, sensors) {
 
         var sensorsArray = fluid.hashToArray(sensors, "sensor");
 
@@ -54,14 +52,14 @@
                 return a.name.localeCompare(b.name);
             });
 
-            gpii.nexusScienceLabDashboard.updateDashboardValues(
+            fluid.nexusScienceLabDashboard.updateDashboardValues(
                 that,
                 sensorsArray
             );
         }
     };
 
-    gpii.nexusScienceLabDashboard.updateDashboardValues = function (that, sortedSensors) {
+    fluid.nexusScienceLabDashboard.updateDashboardValues = function (that, sortedSensors) {
 
         var sensorsArrayIndex = 0;
 
@@ -72,8 +70,8 @@
                 var sensorOnPage = $($(sensorElem).find(that.options.selectors.sensorHeading)).text();
 
                 // Insert any new sensors
-                while (sensorOnPage.localeCompare(gpii.nexusScienceLabDashboard.buildSensorHeading(sortedSensors[sensorsArrayIndex])) === 1) {
-                    $(sensorElem).before(gpii.nexusScienceLabDashboard.buildSensorMarkup(
+                while (sensorOnPage.localeCompare(fluid.nexusScienceLabDashboard.buildSensorHeading(sortedSensors[sensorsArrayIndex])) === 1) {
+                    $(sensorElem).before(fluid.nexusScienceLabDashboard.buildSensorMarkup(
                         that.options.markup.sensor,
                         sortedSensors[sensorsArrayIndex],
                         that.options.numberLocale,
@@ -82,10 +80,10 @@
                     ++sensorsArrayIndex;
                 }
 
-                switch (sensorOnPage.localeCompare(gpii.nexusScienceLabDashboard.buildSensorHeading(sortedSensors[sensorsArrayIndex]))) {
+                switch (sensorOnPage.localeCompare(fluid.nexusScienceLabDashboard.buildSensorHeading(sortedSensors[sensorsArrayIndex]))) {
                     case 0:
                         // Existing value, update it
-                        var newValue = gpii.nexusScienceLabDashboard.buildSensorValue(
+                        var newValue = fluid.nexusScienceLabDashboard.buildSensorValue(
                             sortedSensors[sensorsArrayIndex],
                             that.options.numberLocale,
                             that.options.maximumFractionDigits
@@ -107,7 +105,7 @@
 
         // Add any remaining new sensors from the incoming data
         while (sensorsArrayIndex < sortedSensors.length) {
-            that.container.append(gpii.nexusScienceLabDashboard.buildSensorMarkup(
+            that.container.append(fluid.nexusScienceLabDashboard.buildSensorMarkup(
                 that.options.markup.sensor,
                 sortedSensors[sensorsArrayIndex],
                 that.options.numberLocale,
@@ -117,11 +115,11 @@
         }
     };
 
-    gpii.nexusScienceLabDashboard.buildSensorMarkup = function (markup, sensorData, numberLocale, maximumFractionDigits) {
+    fluid.nexusScienceLabDashboard.buildSensorMarkup = function (markup, sensorData, numberLocale, maximumFractionDigits) {
         return fluid.stringTemplate(markup,
             {
-                sensorHeading: gpii.nexusScienceLabDashboard.buildSensorHeading(sensorData),
-                sensorValue: gpii.nexusScienceLabDashboard.buildSensorValue(
+                sensorHeading: fluid.nexusScienceLabDashboard.buildSensorHeading(sensorData),
+                sensorValue: fluid.nexusScienceLabDashboard.buildSensorValue(
                     sensorData,
                     numberLocale,
                     maximumFractionDigits
@@ -130,7 +128,7 @@
         );
     };
 
-    gpii.nexusScienceLabDashboard.buildSensorHeading = function (sensorData) {
+    fluid.nexusScienceLabDashboard.buildSensorHeading = function (sensorData) {
         if (sensorData.units) {
             return fluid.stringTemplate("%sensorName (%units)", {
                 sensorName: sensorData.name,
@@ -141,7 +139,7 @@
         }
     };
 
-    gpii.nexusScienceLabDashboard.buildSensorValue = function (sensorData, numberLocale, maximumFractionDigits) {
+    fluid.nexusScienceLabDashboard.buildSensorValue = function (sensorData, numberLocale, maximumFractionDigits) {
         return sensorData.value.toLocaleString(numberLocale, {
             maximumFractionDigits: maximumFractionDigits
         });

--- a/science-lab/rpi-sense-hat-driver/RpiSenseHatDriver.js
+++ b/science-lab/rpi-sense-hat-driver/RpiSenseHatDriver.js
@@ -1,21 +1,20 @@
 "use strict";
 
 var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii"),
     nodeimu = require("nodeimu");
 
-fluid.defaults("gpii.nexus.rpiSenseHat", {
+fluid.defaults("fluid.nexus.rpiSenseHat", {
     gradeNames: "fluid.component",
 
     readIntervalMs: 1000,
 
     members: {
-        imu: "@expand:gpii.nexus.rpiSenseHat.constructImu()"
+        imu: "@expand:fluid.nexus.rpiSenseHat.constructImu()"
     },
 
     invokers: {
         getReading: {
-            funcName: "gpii.nexus.rpiSenseHat.getReading",
+            funcName: "fluid.nexus.rpiSenseHat.getReading",
             args: [
                 "{that}",
                 "{that}.imu",
@@ -34,11 +33,11 @@ fluid.defaults("gpii.nexus.rpiSenseHat", {
     }
 });
 
-gpii.nexus.rpiSenseHat.constructImu = function () {
+fluid.nexus.rpiSenseHat.constructImu = function () {
     return new nodeimu.IMU();
 };
 
-gpii.nexus.rpiSenseHat.getReading = function (that, imu, readIntervalMs, onReadingEvent) {
+fluid.nexus.rpiSenseHat.getReading = function (that, imu, readIntervalMs, onReadingEvent) {
     imu.getValue(function (e, data) {
         onReadingEvent.fire(data);
         setTimeout(function () {
@@ -47,20 +46,20 @@ gpii.nexus.rpiSenseHat.getReading = function (that, imu, readIntervalMs, onReadi
     });
 };
 
-fluid.defaults("gpii.nexus.rpiSenseHatDriver", {
+fluid.defaults("fluid.nexus.rpiSenseHatDriver", {
     gradeNames: "fluid.modelComponent",
 
     nexusHost: "localhost",
     nexusPort: 9081,
     nexusPeerComponentPath: "rpiSenseHatTemp",
     nexusPeerComponentOptions: {
-        type: "gpii.nexus.rpiSenseHatDriver.tempSensor"
+        type: "fluid.nexus.rpiSenseHatDriver.tempSensor"
     },
     sensorName: "Temperature",
 
     components: {
         sense: {
-            type: "gpii.nexus.rpiSenseHat",
+            type: "fluid.nexus.rpiSenseHat",
             options: {
                 listeners: {
                     "onReading.log": function (data) {
@@ -98,7 +97,7 @@ fluid.defaults("gpii.nexus.rpiSenseHatDriver", {
                 },
                 listeners: {
                     "{rpiSenseHat}.events.onReading": {
-                        listener: "gpii.nexus.rpiSenseHatDriver.updateTemp",
+                        listener: "fluid.nexus.rpiSenseHatDriver.updateTemp",
                         args: [
                             "{that}",
                             "{arguments}.0" // Sensor reading
@@ -124,6 +123,6 @@ fluid.defaults("gpii.nexus.rpiSenseHatDriver", {
 
 });
 
-gpii.nexus.rpiSenseHatDriver.updateTemp = function (nexusBinding, senseHatData) {
+fluid.nexus.rpiSenseHatDriver.updateTemp = function (nexusBinding, senseHatData) {
     nexusBinding.applier.change("sensorData.value", senseHatData.temperature);
 };

--- a/science-lab/rpi-sense-hat-driver/RunRpiSenseHatDriver.js
+++ b/science-lab/rpi-sense-hat-driver/RunRpiSenseHatDriver.js
@@ -1,9 +1,8 @@
 "use strict";
 
-var fluid = require("infusion"),
-    gpii = fluid.registerNamespace("gpii");
+var fluid = require("infusion");
 
-require("gpii-nexus-client");
+require("infusion-nexus-client");
 require("./RpiSenseHatDriver.js");
 
 var program = require("commander");
@@ -34,22 +33,22 @@ var sensorNames = [];
 sensorNames[1] = "Temperature A";
 sensorNames[2] = "Temperature B";
 
-gpii.nexus.rpiSenseHatDriver.logErrorAndExit = function (error) {
+fluid.nexus.rpiSenseHatDriver.logErrorAndExit = function (error) {
     console.log(error.message);
     process.exit(1);
 };
 
-var driver = gpii.nexus.rpiSenseHatDriver({
+var driver = fluid.nexus.rpiSenseHatDriver({
     nexusHost: nexusHost,
     nexusPort: nexusPort,
     nexusPeerComponentPath: "rpiSenseHatTemp" + senseHatNumber,
     nexusPeerComponentOptions: {
-        type: "gpii.nexus.rpiSenseHatDriver.tempSensor" + senseHatNumber
+        type: "fluid.nexus.rpiSenseHatDriver.tempSensor" + senseHatNumber
     },
     sensorName: sensorNames[senseHatNumber],
     listeners: {
         "onErrorConstructingPeer.exitProcess": {
-            funcName: "gpii.nexus.rpiSenseHatDriver.logErrorAndExit",
+            funcName: "fluid.nexus.rpiSenseHatDriver.logErrorAndExit",
             args: ["{arguments}.0"]
         },
         "onNexusPeerComponentDestroyed.exitProcess": {

--- a/science-lab/sensor-presentations/css/NexusScienceLabVisualizer.css
+++ b/science-lab/sensor-presentations/css/NexusScienceLabVisualizer.css
@@ -27,11 +27,11 @@
     display: none;
 }
 
-.gpiic-visualizer-controls {
+.fluidc-visualizer-controls {
     text-align: center;
     padding-left: 8%;
 }
 
-.gpiic-visualizer-controls label {
+.fluidc-visualizer-controls label {
     font-size: 125%;
 }

--- a/science-lab/sensor-presentations/js/nexusSensorPresentationPanel.js
+++ b/science-lab/sensor-presentations/js/nexusSensorPresentationPanel.js
@@ -4,7 +4,7 @@
     // An "abstract" grade for presenting sensors
     // An implementing grade needs to supply
     // appropriate dynamic components
-    fluid.defaults("gpii.nexusSensorPresentationPanel", {
+    fluid.defaults("fluid.nexusSensorPresentationPanel", {
         gradeNames: ["gpii.nexusWebSocketBoundComponent", "fluid.viewComponent"],
         events: {
             onSensorAppearance: null,
@@ -18,9 +18,9 @@
         },
         dynamicComponents: {
             sensorPresenter: {
-                type: "@expand:gpii.nexusSensorPresentationPanel.getSensorPresenterType({that}, {arguments}.0)",
+                type: "@expand:fluid.nexusSensorPresentationPanel.getSensorPresenterType({that}, {arguments}.0)",
                 createOnEvent: "onSensorAppearance",
-                options: "@expand:gpii.nexusSensorPresentationPanel.getSensorPresenterOptions({arguments}.0, {arguments}.1, {arguments}.2)"
+                options: "@expand:fluid.nexusSensorPresentationPanel.getSensorPresenterOptions({arguments}.0, {arguments}.1, {arguments}.2)"
             }
         },
         members: {
@@ -43,7 +43,7 @@
         },
         invokers: {
             updateSensorPresentations: {
-                funcName: "gpii.nexusSensorPresentationPanel.updateSensorPresentations"
+                funcName: "fluid.nexusSensorPresentationPanel.updateSensorPresentations"
             }
         }
     });
@@ -51,20 +51,20 @@
     // expander function; used to generate sensor sonifiers as sensors
     // are attached; dynamically configures model characteristics and
     // container for display / controls based on the sensorId
-    gpii.nexusSensorPresentationPanel.getSensorPresenterOptions = function (sensorId, sensorName, sensorPresentationPanel) {
+    fluid.nexusSensorPresentationPanel.getSensorPresenterOptions = function (sensorId, sensorName, sensorPresentationPanel) {
 
-        var sensorPresenterModelOptions = gpii.nexusSensorPresentationPanel.getSensorModelOptions(sensorId);
+        var sensorPresenterModelOptions = fluid.nexusSensorPresentationPanel.getSensorModelOptions(sensorId);
 
         var sensorPresenterContainerClass = fluid.stringTemplate(sensorPresentationPanel.options.dynamicComponentContainerOptions.containerIndividualClassTemplate, {sensorId: sensorId});
 
-        var sensorPresenterListenerOptions = gpii.nexusSensorPresentationPanel.getSensorPresenterListenerOptions(sensorId, sensorPresenterContainerClass, sensorName);
+        var sensorPresenterListenerOptions = fluid.nexusSensorPresentationPanel.getSensorPresenterListenerOptions(sensorId, sensorPresenterContainerClass, sensorName);
 
         return sensorPresentationPanel.generatePresenterOptionsBlock (sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass);
     };
 
     // Allows specific grades for specific sensors
     // See visualization or sonification panels for implementation structure
-    gpii.nexusSensorPresentationPanel.getSensorPresenterType = function (that, sensorId) {
+    fluid.nexusSensorPresentationPanel.getSensorPresenterType = function (that, sensorId) {
         var perSensorPresentationGrades = that.options.perSensorPresentationGrades;
         if(perSensorPresentationGrades[sensorId]) {
             return perSensorPresentationGrades[sensorId];
@@ -77,7 +77,7 @@
     // 1) Fires an event when a sensor is added, argument is the sensor ID
     // 2) Fires an aggregrate event when sensors are removed, argument is
     // an array of sensor IDs
-    gpii.nexusSensorPresentationPanel.updateSensorPresentations = function (that, sensors) {
+    fluid.nexusSensorPresentationPanel.updateSensorPresentations = function (that, sensors) {
 
         var sensorsArray = fluid.hashToArray(
             sensors,
@@ -111,7 +111,7 @@
 
     // Generates common model relay options to let a presenter be
     // synchronized with a particular sensor model path
-    gpii.nexusSensorPresentationPanel.getSensorModelOptions = function (sensorId) {
+    fluid.nexusSensorPresentationPanel.getSensorModelOptions = function (sensorId) {
         var sensorModelOptions = {
             sensorId: sensorId,
             description: "{nexusSensorPresentationPanel}.model.sensors." + sensorId + ".name",
@@ -145,10 +145,10 @@
     // Calls a function of the nexusSensorPresentation panel
     // to let it clean up the container after the associated
     // presenter has been destroyed
-    gpii.nexusSensorPresentationPanel.getSensorPresenterListenerOptions = function (sensorId, sensorContainerClass, sensorName) {
+    fluid.nexusSensorPresentationPanel.getSensorPresenterListenerOptions = function (sensorId, sensorContainerClass, sensorName) {
         var sensorListenerOptions = {
            "onCreate.appendSensorDisplayContainer": {
-               funcName: "gpii.nexusSensorPresentationPanel.addSensorDisplayContainer",
+               funcName: "fluid.nexusSensorPresentationPanel.addSensorDisplayContainer",
                args: ["{nexusSensorPresentationPanel}", sensorContainerClass, sensorName]
            },
            "onCreate.fireOnSensorDisplayContainerAppended": {
@@ -156,12 +156,12 @@
                priority: "after:appendSensorDisplayContainer"
            },
            "{nexusSensorPresentationPanel}.events.onSensorRemoval": {
-              funcName: "gpii.nexusSensorPresentationPanel.checkForRemoval",
+              funcName: "fluid.nexusSensorPresentationPanel.checkForRemoval",
               args: ["{that}", "{that}.sensor", "{arguments}.0"],
               namespace: "removeSensorPresenter-"+sensorId
           },
            "onDestroy.removeSensorDisplayContainer": {
-               funcName: "gpii.nexusSensorPresentationPanel.removeSensorDisplayContainer",
+               funcName: "fluid.nexusSensorPresentationPanel.removeSensorDisplayContainer",
                args: ["{nexusSensorPresentationPanel}", sensorContainerClass]
            }
         };
@@ -172,7 +172,7 @@
 
     // Adds sensor display containers in alphabetical order by
     // sensor name
-    gpii.nexusSensorPresentationPanel.addSensorDisplayContainer = function (nexusSensorPresentationPanel, sensorContainerClass, sensorName) {
+    fluid.nexusSensorPresentationPanel.addSensorDisplayContainer = function (nexusSensorPresentationPanel, sensorContainerClass, sensorName) {
         var attachedContainers = nexusSensorPresentationPanel.attachedContainers;
 
         attachedContainers.push ({"sensorName": sensorName, "containerClass": sensorContainerClass});
@@ -205,7 +205,7 @@
     // Function used by the nexusSensorPresentationPanel to remove
     // dynamically generated container markup when a sensor is
     // removed
-    gpii.nexusSensorPresentationPanel.removeSensorDisplayContainer = function (nexusSensorPresentationPanel, sensorContainerClass) {
+    fluid.nexusSensorPresentationPanel.removeSensorDisplayContainer = function (nexusSensorPresentationPanel, sensorContainerClass) {
 
         // Remove from the attached containers index
         var attachedContainers = nexusSensorPresentationPanel.attachedContainers;
@@ -229,14 +229,14 @@
     // Function used by a sensorPresenter to check the array of
     // removed sensor IDs and invoke its own destroy function
     // if it matches a removed sensor ID
-    gpii.nexusSensorPresentationPanel.checkForRemoval = function (sensorPresenter, sensor, removedSensorIds) {
+    fluid.nexusSensorPresentationPanel.checkForRemoval = function (sensorPresenter, sensor, removedSensorIds) {
         if(fluid.contains(removedSensorIds,fluid.get(sensor.model, "sensorId"))) {
             sensorPresenter.destroy();
         }
     };
 
     // Mix-in grade for viewComponents - start hidden, then fade in
-    fluid.defaults("gpii.nexusSensorPresentationPanel.fadeInPresenter", {
+    fluid.defaults("fluid.nexusSensorPresentationPanel.fadeInPresenter", {
         listeners: {
             // Start hidden
             "onCreate.hideContainer": {

--- a/science-lab/sensor-presentations/js/nexusSensorSonificationPanel.js
+++ b/science-lab/sensor-presentations/js/nexusSensorSonificationPanel.js
@@ -1,29 +1,27 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
-
     // Sonification presentation panel
-    fluid.defaults("gpii.nexusSensorSonificationPanel", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel"],
+    fluid.defaults("fluid.nexusSensorSonificationPanel", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel"],
         perSensorPresentationGrades: {
-            "fakeSensorPH": "gpii.sensorPlayer.pH",
-            "phSensor": "gpii.sensorPlayer.pH"
+            "fakeSensorPH": "fluid.sensorPlayer.pH",
+            "phSensor": "fluid.sensorPlayer.pH"
         },
         dynamicComponentContainerOptions: {
             // fluid.stringTemplate
             containerIndividualClassTemplate: "nexus-nexusSensorSonificationPanel-sensorDisplay-%sensorId"
         },
-        defaultSensorPresentationGrade: "gpii.sensorPlayer",
+        defaultSensorPresentationGrade: "fluid.sensorPlayer",
         invokers: {
             "generatePresenterOptionsBlock": {
-                funcName: "gpii.nexusSensorSonificationPanel.getSensorPresenterOptionsBlock",
+                funcName: "fluid.nexusSensorSonificationPanel.getSensorPresenterOptionsBlock",
                 args: ["{arguments}.0", "{arguments}.1", "{arguments}.2"]
             }
         }
     });
 
-    gpii.nexusSensorSonificationPanel.getSensorPresenterOptionsBlock = function (sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass) {
+    fluid.nexusSensorSonificationPanel.getSensorPresenterOptionsBlock = function (sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass) {
         var optionsBlock =
         {
             events: {
@@ -37,7 +35,7 @@
                     }
                 },
                 sensorSonifierDisplay: {
-                    type: "gpii.nexusSensorSonificationPanel.sensorSonifierDisplay",
+                    type: "fluid.nexusSensorSonificationPanel.sensorSonifierDisplay",
                     container: "." + sensorPresenterContainerClass,
                     createOnEvent: "{sensorPlayer}.events.onSensorDisplayContainerAppended"
                 }
@@ -46,8 +44,8 @@
         return optionsBlock;
     };
 
-    fluid.defaults("gpii.nexusSensorSonificationPanel.sensorSonifierDisplay", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel.fadeInPresenter", "fluid.viewComponent"],
+    fluid.defaults("fluid.nexusSensorSonificationPanel.sensorSonifierDisplay", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel.fadeInPresenter", "fluid.viewComponent"],
         events: {
             displayTemplateReady: null
         },
@@ -69,14 +67,14 @@
                 func: "{that}.events.displayTemplateReady.fire"
             },
             "onCreate.bindSynthControls": {
-                func: "gpii.sensorPlayer.sensorDisplayDebug.bindSynthControls",
+                func: "fluid.sensorPlayer.sensorDisplayDebug.bindSynthControls",
                 args: ["{that}", "{sensorSonifier}"]
             }
         },
         components: {
             sensorNameDisplay: {
                 createOnEvent: "{sensorSonifierDisplay}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorSonifierDisplay}.dom.sensorNameDisplay",
                 options: {
                     model: {

--- a/science-lab/sensor-presentations/js/nexusSensorVisualizationPanel.js
+++ b/science-lab/sensor-presentations/js/nexusSensorVisualizationPanel.js
@@ -1,44 +1,42 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
-
     // Sonification presentation panel
-    fluid.defaults("gpii.nexusSensorVisualizationPanel", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel"],
+    fluid.defaults("fluid.nexusSensorVisualizationPanel", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel"],
         // Key-value pairs of sensorIds / sensorPresenter grades
         perSensorPresentationGrades: {
-            "fakeSensorPH": "gpii.nexusSensorVisualizer.pHScale",
-            "fakeSensorTemperature": "gpii.nexusSensorVisualizer.temperature",
-            "rpiTempSensor1": "gpii.nexusSensorVisualizer.temperature",
-            "rpiTempSensor2": "gpii.nexusSensorVisualizer.temperature",
-            "phSensor": "gpii.nexusSensorVisualizer.pHScale"
+            "fakeSensorPH": "fluid.nexusSensorVisualizer.pHScale",
+            "fakeSensorTemperature": "fluid.nexusSensorVisualizer.temperature",
+            "rpiTempSensor1": "fluid.nexusSensorVisualizer.temperature",
+            "rpiTempSensor2": "fluid.nexusSensorVisualizer.temperature",
+            "phSensor": "fluid.nexusSensorVisualizer.pHScale"
         },
         dynamicComponentContainerOptions: {
             // fluid.stringTemplate
             containerIndividualClassTemplate: "nexus-nexusSensorSonificationPanel-sensorDisplay-%sensorId"
         },
-        defaultSensorPresentationGrade: "gpii.nexusSensorVisualizer.realTimeScale",
+        defaultSensorPresentationGrade: "fluid.nexusSensorVisualizer.realTimeScale",
         invokers: {
             "generatePresenterOptionsBlock": {
-                funcName: "gpii.nexusSensorVisualizationPanel.getSensorPresenterOptionsBlock",
+                funcName: "fluid.nexusSensorVisualizationPanel.getSensorPresenterOptionsBlock",
                 args: ["{arguments}.0", "{arguments}.1", "{arguments}.2"]
             }
         }
     });
 
-    gpii.nexusSensorVisualizationPanel.getSensorPresenterOptions = function (sensorId, sensorName, sensorPresentationPanel) {
+    fluid.nexusSensorVisualizationPanel.getSensorPresenterOptions = function (sensorId, sensorName, sensorPresentationPanel) {
 
-        var sensorPresenterModelOptions = gpii.nexusSensorPresentationPanel.getSensorModelOptions(sensorId);
+        var sensorPresenterModelOptions = fluid.nexusSensorPresentationPanel.getSensorModelOptions(sensorId);
 
         var sensorPresenterContainerClass = fluid.stringTemplate(sensorPresentationPanel.options.dynamicComponentContainerOptions.containerIndividualClassTemplate, {sensorId: sensorId});
 
-        var sensorPresenterListenerOptions = gpii.nexusSensorPresentationPanel.getSensorPresenterListenerOptions(sensorId, sensorPresenterContainerClass, sensorName);
+        var sensorPresenterListenerOptions = fluid.nexusSensorPresentationPanel.getSensorPresenterListenerOptions(sensorId, sensorPresenterContainerClass, sensorName);
 
         return sensorPresentationPanel.generatePresenterOptionsBlock(sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass);
     };
 
-    gpii.nexusSensorVisualizationPanel.getSensorPresenterOptionsBlock = function (sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass) {
+    fluid.nexusSensorVisualizationPanel.getSensorPresenterOptionsBlock = function (sensorPresenterModelOptions, sensorPresenterListenerOptions, sensorPresenterContainerClass) {
         var optionsBlock = {
                 events: {
                     onSensorDisplayContainerAppended: null
@@ -60,7 +58,7 @@
     };
 
     // Abstract grade used by sensor visualizer
-    fluid.defaults("gpii.nexusSensorVisualizerBase", {
+    fluid.defaults("fluid.nexusSensorVisualizerBase", {
         gradeNames: ["fluid.component"],
         events: {
             onSensorDisplayContainerAppended: null
@@ -85,7 +83,7 @@
         }
     });
 
-    fluid.defaults("gpii.nexusVisualizerBase", {
+    fluid.defaults("fluid.nexusVisualizerBase", {
         gradeNames: ["floe.svgDrawingArea"],
         events: {
             onUpdateCompleted: null

--- a/science-lab/sensor-presentations/js/sensorPlayer.js
+++ b/science-lab/sensor-presentations/js/sensorPlayer.js
@@ -2,7 +2,7 @@
 
     "use strict";
 
-    fluid.defaults("gpii.sensorPlayer.sensor", {
+    fluid.defaults("fluid.sensorPlayer.sensor", {
         gradeNames: ["fluid.modelComponent"],
         model: {
             sensorValue: 50,
@@ -13,7 +13,7 @@
     });
 
     // Base sonifier definition
-    fluid.defaults("gpii.sensorPlayer.sensorSonifier.base", {
+    fluid.defaults("fluid.sensorPlayer.sensorSonifier.base", {
         gradeNames: ["fluid.modelComponent"],
         model: {
             sensorMax: 100,
@@ -36,18 +36,18 @@
     });
 
     // A sensor sonifier that uses the scaling synth
-    fluid.defaults("gpii.sensorPlayer.sensorSonifier.scaling", {
-        gradeNames: ["gpii.sensorPlayer.sensorSonifier.base"],
+    fluid.defaults("fluid.sensorPlayer.sensorSonifier.scaling", {
+        gradeNames: ["fluid.sensorPlayer.sensorSonifier.base"],
         components: {
             synth: {
-                type: "gpii.sensorPlayer.scalingSynth"
+                type: "fluid.sensorPlayer.scalingSynth"
             }
         }
     });
 
     // A pH-sensor specific sonifier
-    fluid.defaults("gpii.sensorPlayer.sensorSonifier.pH", {
-        gradeNames: ["gpii.sensorPlayer.sensorSonifier.base"],
+    fluid.defaults("fluid.sensorPlayer.sensorSonifier.pH", {
+        gradeNames: ["fluid.sensorPlayer.sensorSonifier.base"],
         components: {
             sonifier: {
                 type: "floe.scienceLab.phSonification",
@@ -64,7 +64,7 @@
                             }
                         },
                         synth: {
-                            type: "gpii.sensorPlayer.pHSynth",
+                            type: "fluid.sensorPlayer.pHSynth",
                             options: {
                                 model: {
                                     valueInformation: {
@@ -82,12 +82,12 @@
         }
     });
 
-    fluid.defaults("gpii.sensorPlayer.pHSynth", {
+    fluid.defaults("fluid.sensorPlayer.pHSynth", {
         gradeNames: ["flock.modelSynth", "floe.scienceLab.phSynth"],
         modelRelay: [{
             target: "inputs.distortion.amount",
             singleTransform: {
-                type: "gpii.sensorPlayer.transforms.polarityScale",
+                type: "fluid.sensorPlayer.transforms.polarityScale",
                 input: "{that}.model.valueInformation.current",
                 inputScaleMax: "{that}.model.valueInformation.max",
                 inputScaleMin: "{that}.model.valueInformation.min",
@@ -98,7 +98,7 @@
         {
             target: "inputs.granulator.speed",
             singleTransform: {
-                type: "gpii.sensorPlayer.transforms.minMaxScale",
+                type: "fluid.sensorPlayer.transforms.minMaxScale",
                 input: "{that}.model.valueInformation.current",
                 inputScaleMax: "{that}.model.valueInformation.max",
                 inputScaleMin: "{that}.model.valueInformation.min",
@@ -110,12 +110,12 @@
 
     // A model-driven synth that scales model values
     // with specified min / max to a min/max frequency range
-    fluid.defaults("gpii.sensorPlayer.scalingSynth", {
+    fluid.defaults("fluid.sensorPlayer.scalingSynth", {
         gradeNames: ["flock.modelSynth"],
         modelRelay: [{
             target: "inputs.carrier.freq",
             singleTransform: {
-                type: "gpii.sensorPlayer.transforms.minMaxScale",
+                type: "fluid.sensorPlayer.transforms.minMaxScale",
                 input: "{that}.model.valueInformation.current",
                 inputScaleMax: "{that}.model.valueInformation.max",
                 inputScaleMin: "{that}.model.valueInformation.min",
@@ -192,9 +192,9 @@
     });
 
 
-    fluid.registerNamespace("gpii.sensorPlayer.transforms");
+    fluid.registerNamespace("fluid.sensorPlayer.transforms");
 
-    fluid.defaults("gpii.sensorPlayer.transforms.minMaxScale", {
+    fluid.defaults("fluid.sensorPlayer.transforms.minMaxScale", {
         "gradeNames": [ "fluid.standardTransformFunction", "fluid.multiInputTransformFunction" ],
         "inputVariables": {
             "inputScaleMax": 100,
@@ -204,7 +204,7 @@
         }
     });
 
-    gpii.sensorPlayer.transforms.clampInput = function (input, inputScaleMax, inputScaleMin) {
+    fluid.sensorPlayer.transforms.clampInput = function (input, inputScaleMax, inputScaleMin) {
         if(input > inputScaleMax) {
             input = inputScaleMax;
         } else if (input < inputScaleMin) {
@@ -213,11 +213,11 @@
         return input;
     };
 
-    gpii.sensorPlayer.transforms.minMaxScale = function (input, extraInputs) {
+    fluid.sensorPlayer.transforms.minMaxScale = function (input, extraInputs) {
         var inputScaleMax = extraInputs.inputScaleMax(),
             inputScaleMin = extraInputs.inputScaleMin();
 
-        input = gpii.sensorPlayer.transforms.clampInput(input, inputScaleMax, inputScaleMin);
+        input = fluid.sensorPlayer.transforms.clampInput(input, inputScaleMax, inputScaleMin);
 
         var scaledValue = ((extraInputs.outputScaleMax() - extraInputs.outputScaleMin()) * (input - extraInputs.inputScaleMin()) / (extraInputs.inputScaleMax() - extraInputs.inputScaleMin())) + extraInputs.outputScaleMin();
         return scaledValue;
@@ -225,7 +225,7 @@
 
     // Given min and max for input and output, returns a value calculated from
     // the distance of the input value from the midpoint of input min and max
-    fluid.defaults("gpii.sensorPlayer.transforms.polarityScale", {
+    fluid.defaults("fluid.sensorPlayer.transforms.polarityScale", {
         "gradeNames": [ "fluid.standardTransformFunction", "fluid.multiInputTransformFunction" ],
         "inputVariables": {
             "inputScaleMax": 14,
@@ -235,13 +235,13 @@
         }
     });
 
-    gpii.sensorPlayer.transforms.polarityScale = function (input, extraInputs) {
+    fluid.sensorPlayer.transforms.polarityScale = function (input, extraInputs) {
         var inputScaleMax = extraInputs.inputScaleMax(),
             inputScaleMin = extraInputs.inputScaleMin(),
             outputScaleMax = extraInputs.outputScaleMax(),
             outputScaleMin = extraInputs.outputScaleMin();
 
-            input = gpii.sensorPlayer.transforms.clampInput(input, inputScaleMax, inputScaleMin);
+            input = fluid.sensorPlayer.transforms.clampInput(input, inputScaleMax, inputScaleMin);
 
             // Get the input midpoint
             var inputMidpoint = (inputScaleMin + inputScaleMax) / 2;
@@ -266,7 +266,7 @@
             return returnValue;
     };
 
-    fluid.defaults("gpii.sensorPlayer.valueDisplay", {
+    fluid.defaults("fluid.sensorPlayer.valueDisplay", {
         gradeNames: ["fluid.viewComponent"],
         model: {
             value: "Hello, World!"
@@ -298,7 +298,7 @@
         }
     });
 
-    fluid.defaults("gpii.sensorPlayer.sensorDisplayDebug", {
+    fluid.defaults("fluid.sensorPlayer.sensorDisplayDebug", {
         gradeNames: ["fluid.viewComponent"],
         events: {
             displayTemplateReady: null
@@ -325,14 +325,14 @@
                 func: "{that}.events.displayTemplateReady.fire"
             },
             "onCreate.bindSynthControls": {
-                func: "gpii.sensorPlayer.sensorDisplayDebug.bindSynthControls",
+                func: "fluid.sensorPlayer.sensorDisplayDebug.bindSynthControls",
                 args: ["{that}", "{sensorPlayer}"]
             }
         },
         components: {
             descriptionDisplay: {
                 createOnEvent: "{sensorDisplayDebug}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorDisplayDebug}.dom.descriptionDisplay",
                 options: {
                     model: {
@@ -345,7 +345,7 @@
             },
             sensorMinDisplay: {
                 createOnEvent: "{sensorDisplayDebug}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorDisplayDebug}.dom.sensorMinDisplay",
                 options: {
                     model: {
@@ -358,7 +358,7 @@
             },
             sensorMaxDisplay: {
                 createOnEvent: "{sensorDisplayDebug}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorDisplayDebug}.dom.sensorMaxDisplay",
                 options: {
                     model: {
@@ -371,7 +371,7 @@
             },
             sensorDisplayDebug: {
                 createOnEvent: "{sensorDisplayDebug}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorDisplayDebug}.dom.sensorValueDisplay",
                 options: {
                     model: {
@@ -384,7 +384,7 @@
             },
             synthFreqDisplay: {
                 createOnEvent: "{sensorDisplayDebug}.events.displayTemplateReady",
-                type: "gpii.sensorPlayer.valueDisplay",
+                type: "fluid.sensorPlayer.valueDisplay",
                 container: "{sensorDisplayDebug}.dom.synthFreqDisplay",
                 options: {
                     model: {
@@ -398,7 +398,7 @@
         }
     });
 
-    gpii.sensorPlayer.sensorDisplayDebug.bindSynthControls = function (that, sensorSonifier) {
+    fluid.sensorPlayer.sensorDisplayDebug.bindSynthControls = function (that, sensorSonifier) {
         var muteControl = that.locate("muteControl");
         var midpointToneControl = that.locate("midpointToneControl");
 
@@ -441,14 +441,14 @@
     };
 
     // Base
-    fluid.defaults("gpii.sensorPlayer", {
+    fluid.defaults("fluid.sensorPlayer", {
         gradeNames: ["fluid.modelComponent"],
         components: {
             sensor: {
-                type: "gpii.sensorPlayer.sensor"
+                type: "fluid.sensorPlayer.sensor"
             },
             sensorSonifier: {
-                type: "gpii.sensorPlayer.sensorSonifier.scaling",
+                type: "fluid.sensorPlayer.sensorSonifier.scaling",
                 options: {
                     model: {
                         sensorValue: "{sensor}.model.sensorValue",
@@ -460,11 +460,11 @@
         }
     });
 
-    fluid.defaults("gpii.sensorPlayer.pH", {
-        gradeNames: ["gpii.sensorPlayer"],
+    fluid.defaults("fluid.sensorPlayer.pH", {
+        gradeNames: ["fluid.sensorPlayer"],
         components: {
             sensorSonifier: {
-                type: "gpii.sensorPlayer.sensorSonifier.pH"
+                type: "fluid.sensorPlayer.sensorSonifier.pH"
             }
         }
     });

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-colorScale.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-colorScale.js
@@ -1,14 +1,13 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
     var d3 = fluid.registerNamespace("d3");
 
-    fluid.defaults("gpii.nexusSensorVisualizer.colorScale", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.colorScale", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.colorScale.visualizer",
+                type: "fluid.nexusSensorVisualizer.colorScale.visualizer",
                 options: {
                     scaleOptions: {
                         min: "{colorScale}.sensor.model.sensorMin",
@@ -23,8 +22,8 @@
     });
 
     // A generic color scale with an indicator, y-axis and labels
-    fluid.defaults("gpii.nexusSensorVisualizer.colorScale.visualizer", {
-        gradeNames: ["gpii.nexusVisualizerBase", "floe.svgDrawingArea"],
+    fluid.defaults("fluid.nexusSensorVisualizer.colorScale.visualizer", {
+        gradeNames: ["fluid.nexusVisualizerBase", "floe.svgDrawingArea"],
         model: {
             svgTitle: "An animated scale.",
             svgDescription: "An animated scale."
@@ -73,15 +72,15 @@
         },
         invokers: {
             getIndicatorColor: {
-                funcName: "gpii.nexusSensorVisualizer.colorScale.visualizer.getIndicatorColor",
+                funcName: "fluid.nexusSensorVisualizer.colorScale.visualizer.getIndicatorColor",
                 args: ["{that}", "{arguments}.0"]
             },
             createVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.colorScale.visualizer.createVisualizer",
+                funcName: "fluid.nexusSensorVisualizer.colorScale.visualizer.createVisualizer",
                 args: ["{that}"]
             },
             updateVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.colorScale.visualizer.updateVisualization"
+                funcName: "fluid.nexusSensorVisualizer.colorScale.visualizer.updateVisualization"
             }
         },
         listeners: {
@@ -98,7 +97,7 @@
         }
     });
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createYScale = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createYScale = function (that) {
 
         var h = that.options.svgOptions.height,
             padding = that.options.scaleOptions.padding,
@@ -111,7 +110,7 @@
                .range([h - padding, 0 + padding]);
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createColorScale = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createColorScale = function (that) {
         var h = that.options.svgOptions.height,
             w = that.options.svgOptions.width,
             padding = that.options.scaleOptions.padding,
@@ -159,7 +158,7 @@
 
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createColorScaleLabels = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createColorScaleLabels = function (that) {
 
         var colors = that.options.scaleOptions.colors,
             textOptions = that.options.scaleOptions.textOptions,
@@ -184,7 +183,7 @@
 
         fluid.each(colors, function(color, index) {
             svg.append("text")
-              .text(gpii.nexusSensorVisualizer.colorScale.visualizer.getColorScaleLabelText(index, textOptions, colorLabelScaleRange))
+              .text(fluid.nexusSensorVisualizer.colorScale.visualizer.getColorScaleLabelText(index, textOptions, colorLabelScaleRange))
               .attr({
                 "class": "nexusc-colorScale-colorBarLabels",
                 "text-anchor": "middle",
@@ -199,7 +198,7 @@
         });
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.getColorScaleLabelText = function (index, textOptions, colorLabelScaleRange) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.getColorScaleLabelText = function (index, textOptions, colorLabelScaleRange) {
 
         var template = textOptions.labels.template,
             valueDecimalPlaces = textOptions.labels.valueDecimalPlaces;
@@ -219,7 +218,7 @@
     };
 
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createPositionedText = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createPositionedText = function (that) {
         var positionedTextValues = that.options.scaleOptions.textOptions.positionedText,
             leftPadding = that.options.scaleOptions.leftPadding,
             w = that.options.svgOptions.width,
@@ -266,7 +265,7 @@
         });
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createIndicator = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createIndicator = function (that) {
         // Draw the PH indicator
 
         var svg = that.svg;
@@ -289,7 +288,7 @@
         });
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createGradients = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createGradients = function (that) {
         var gradientMarkup = that.options.scaleOptions.gradientMarkup;
         fluid.each(gradientMarkup, function(gradient) {
             var defs = that.svg.append("defs");
@@ -297,7 +296,7 @@
         });
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createVisualizer = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createVisualizer = function (that) {
 
         var h = that.options.svgOptions.height,
             padding = that.options.scaleOptions.padding,
@@ -307,22 +306,22 @@
 
     that.barHeight = (h - padding) / colorScaleLength;
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createYScale(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createYScale(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createGradients(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createGradients(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createYAxis(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createYAxis(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createColorScale(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createColorScale(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createColorScaleLabels(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createColorScaleLabels(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createPositionedText(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createPositionedText(that);
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createIndicator(that);
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createIndicator(that);
  };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.updateVisualization = function (that, change) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.updateVisualization = function (that, change) {
             var newIndicatorLocation = that.yScale(change.value) - 15;
             var newIndicatorColor = that.getIndicatorColor(change.value);
             var transitionDuration = that.options.visualizerOptions.transitionDuration;
@@ -339,12 +338,12 @@
             });
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.getIndicatorColor = function (that, indicatorValue) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.getIndicatorColor = function (that, indicatorValue) {
         var valueToColorScale = that.valueToColorScale;
         return valueToColorScale(indicatorValue);
     };
 
-    gpii.nexusSensorVisualizer.colorScale.visualizer.createYAxis = function (that) {
+    fluid.nexusSensorVisualizer.colorScale.visualizer.createYAxis = function (that) {
         var leftPadding = that.options.scaleOptions.leftPadding;
 
         var yAxis = d3.svg.axis().scale(that.yScale).orient("left").innerTickSize(25);

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-lineChart.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-lineChart.js
@@ -1,12 +1,11 @@
 (function () {
     "use strict";
-    var gpii = fluid.registerNamespace("gpii");
 
-    fluid.defaults("gpii.nexusSensorVisualizer.lineChart", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.lineChart", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.lineChart.visualizer",
+                type: "fluid.nexusSensorVisualizer.lineChart.visualizer",
                 options: {
                     scaleOptions: {
                         // transform rules to apply to yScale min
@@ -32,7 +31,7 @@
         }
     });
 
-    gpii.nexusSensorVisualizer.lineChart.accumulateSensorValues = function (sensorValueAccumulator, visualizer, change) {
+    fluid.nexusSensorVisualizer.lineChart.accumulateSensorValues = function (sensorValueAccumulator, visualizer, change) {
 
         var maxValuesRetained = fluid.get(sensorValueAccumulator.model, "maxValuesRetained");
 
@@ -55,8 +54,8 @@
         visualizer.applier.change("dataSet", currentSensorValues);
     };
 
-    fluid.defaults("gpii.nexusSensorVisualizer.lineChart.visualizer", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel.fadeInPresenter", "floe.chartAuthoring.lineChart.timeSeriesSingleDataSet", "gpii.nexusVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.lineChart.visualizer", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel.fadeInPresenter", "floe.chartAuthoring.lineChart.timeSeriesSingleDataSet", "fluid.nexusVisualizerBase"],
         invokers: {
             transitionChartLine: {
                 funcName: "floe.chartAuthoring.lineChart.timeSeries.line.updateChartLine.defaultTransition"
@@ -66,7 +65,7 @@
                 funcName: "fluid.identity"
             },
             updateVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.lineChart.accumulateSensorValues",
+                funcName: "fluid.nexusSensorVisualizer.lineChart.accumulateSensorValues",
                 args: ["{sensorValueAccumulator}", "{arguments}.0", "{arguments}.1"]
             }
         },

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-pHScale.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-pHScale.js
@@ -1,25 +1,23 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
-
     // A specifically formatted pH color scale, based on universal
     // indicator colors, and with some positioned example text
-    fluid.defaults("gpii.nexusSensorVisualizer.pHScale", {
-        gradeNames: ["gpii.nexusSensorVisualizer.colorScale"],
+    fluid.defaults("fluid.nexusSensorVisualizer.pHScale", {
+        gradeNames: ["fluid.nexusSensorVisualizer.colorScale"],
         components: {
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.pHScale.visualizer",
+                type: "fluid.nexusSensorVisualizer.pHScale.visualizer",
                 options: {
                     selectors: {
-                        "displayExamplesCheckbox": ".gpiic-visualizer-displayExamples",
+                        "displayExamplesCheckbox": ".fluidc-visualizer-displayExamples",
                         "pHScaleExamples": ".nexusc-colorScale-positionedText"
                     },
                     listeners: {
                         "onCreate.appendControls": {
                             "this": "{that}.container",
                             method: "append",
-                            args: "<form class='gpiic-visualizer-controls'><label>Show Examples <input class='gpiic-visualizer-displayExamples' type='checkbox' checked /></label></form>"
+                            args: "<form class='fluidc-visualizer-controls'><label>Show Examples <input class='fluidc-visualizer-displayExamples' type='checkbox' checked /></label></form>"
                         },
                         "onCreate.bindControls": {
                             "this": "{that}.dom.displayExamplesCheckbox",
@@ -29,7 +27,7 @@
                     },
                     invokers: {
                         toggleExamples: {
-                            funcName: "gpii.nexusSensorVisualizer.pHScale.toggleExamples",
+                            funcName: "fluid.nexusSensorVisualizer.pHScale.toggleExamples",
                             args: ["{that}"]
                         }
                     }
@@ -38,7 +36,7 @@
         }
     });
 
-    gpii.nexusSensorVisualizer.pHScale.toggleExamples = function (that) {
+    fluid.nexusSensorVisualizer.pHScale.toggleExamples = function (that) {
         var checked = that.locate("displayExamplesCheckbox").prop("checked");
         if(checked) {
             that.locate("pHScaleExamples").fadeIn();
@@ -47,8 +45,8 @@
         }
     };
 
-    fluid.defaults("gpii.nexusSensorVisualizer.pHScale.visualizer", {
-        gradeNames: ["gpii.nexusSensorVisualizer.colorScale.visualizer"],
+    fluid.defaults("fluid.nexusSensorVisualizer.pHScale.visualizer", {
+        gradeNames: ["fluid.nexusSensorVisualizer.colorScale.visualizer"],
         model: {
             svgTitle: "An animated pH scale.",
             svgDescription: "An animated ph scale."

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-realTimeScale.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-realTimeScale.js
@@ -1,14 +1,13 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
     var d3 = fluid.registerNamespace("d3");
 
-    fluid.defaults("gpii.nexusSensorVisualizer.realTimeScale", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.realTimeScale", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.realTimeScale.visualizer",
+                type: "fluid.nexusSensorVisualizer.realTimeScale.visualizer",
                 options: {
                     scaleOptions: {
                         min: "{realTimeScale}.sensor.model.sensorMin",
@@ -22,8 +21,8 @@
         }
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizer.realTimeScale.visualizer", {
-        gradeNames: ["gpii.nexusVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.realTimeScale.visualizer", {
+        gradeNames: ["fluid.nexusVisualizerBase"],
         model: {
             svgTitle: "An animated real-time scale.",
             svgDescription: "An animated real-time scale."
@@ -47,16 +46,16 @@
         },
         invokers: {
             "createVisualizer": {
-                funcName: "gpii.nexusSensorVisualizer.realTimeScale.visualizer.createRealTimeVisualizer",
+                funcName: "fluid.nexusSensorVisualizer.realTimeScale.visualizer.createRealTimeVisualizer",
                 args: ["{that}"]
             },
             "updateVisualizer": {
-                funcName: "gpii.nexusSensorVisualizer.realTimeScale.visualizer.updateVisualization"
+                funcName: "fluid.nexusSensorVisualizer.realTimeScale.visualizer.updateVisualization"
             }
         }
     });
 
-    gpii.nexusSensorVisualizer.realTimeScale.visualizer.createSensorValueIndicator = function (that) {
+    fluid.nexusSensorVisualizer.realTimeScale.visualizer.createSensorValueIndicator = function (that) {
         var h = that.options.svgOptions.height,
             w = that.options.svgOptions.width,
             padding = that.options.scaleOptions.padding,
@@ -81,7 +80,7 @@
           });
     };
 
-    gpii.nexusSensorVisualizer.realTimeScale.visualizer.createRealTimeVisualizer = function (that) {
+    fluid.nexusSensorVisualizer.realTimeScale.visualizer.createRealTimeVisualizer = function (that) {
 
         var h = that.options.svgOptions.height,
             padding = that.options.scaleOptions.padding,
@@ -93,11 +92,11 @@
                .domain([scaleMin, scaleMax])
                .range([h - padding, 0 + padding]);
 
-    gpii.nexusSensorVisualizer.realTimeScale.visualizer.createYAxis(that);
-    gpii.nexusSensorVisualizer.realTimeScale.visualizer.createSensorValueIndicator(that);
+    fluid.nexusSensorVisualizer.realTimeScale.visualizer.createYAxis(that);
+    fluid.nexusSensorVisualizer.realTimeScale.visualizer.createSensorValueIndicator(that);
  };
 
- gpii.nexusSensorVisualizer.realTimeScale.visualizer.createYAxis = function (that) {
+ fluid.nexusSensorVisualizer.realTimeScale.visualizer.createYAxis = function (that) {
      var leftPadding = that.options.scaleOptions.leftPadding;
 
      var yAxis = d3.svg.axis().scale(that.yScale).orient("left").innerTickSize(25);
@@ -106,7 +105,7 @@
         .attr("transform", "translate(" + leftPadding + ")");
  };
 
-    gpii.nexusSensorVisualizer.realTimeScale.visualizer.updateVisualization = function (visualizer, change) {
+    fluid.nexusSensorVisualizer.realTimeScale.visualizer.updateVisualization = function (visualizer, change) {
 
         var h = visualizer.options.svgOptions.height,
             padding = visualizer.options.scaleOptions.padding;

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-sensorPercentageVisualizers.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-sensorPercentageVisualizers.js
@@ -1,13 +1,12 @@
 (function () {
     "use strict";
-    var gpii = fluid.registerNamespace("gpii");
 
-    fluid.defaults("gpii.nexusSensorVisualizer.sensorPercentage", {
+    fluid.defaults("fluid.nexusSensorVisualizer.sensorPercentage", {
         gradeNames: ["fluid.modelComponent"],
         modelRelay: [{
             target: "sensorPercentage",
             singleTransform: {
-                type: "gpii.sensorPlayer.transforms.minMaxScale",
+                type: "fluid.sensorPlayer.transforms.minMaxScale",
                 input: "{sensor}.model.sensorValue",
                 inputScaleMax: "{sensor}.model.sensorMax",
                 inputScaleMin: "{sensor}.model.sensorMin",
@@ -17,22 +16,22 @@
         }]
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizer.circleRadius", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.circleRadius", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             sensor: {
                 options: {
-                    gradeNames: ["gpii.nexusSensorVisualizer.sensorPercentage"]
+                    gradeNames: ["fluid.nexusSensorVisualizer.sensorPercentage"]
                 }
             },
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.circleRadius.visualizer"
+                type: "fluid.nexusSensorVisualizer.circleRadius.visualizer"
             }
         }
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizer.circleRadius.visualizer", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel.fadeInPresenter",  "gpii.nexusVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.circleRadius.visualizer", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel.fadeInPresenter",  "fluid.nexusVisualizerBase"],
         selectors: {
             sensorValueIndicator: ".nexus-nexusSensorVisualizationPanel-sensorDisplay-circle"
         },
@@ -42,16 +41,16 @@
         },
         invokers: {
             createVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.circleRadius.visualizer.createVisualizer",
+                funcName: "fluid.nexusSensorVisualizer.circleRadius.visualizer.createVisualizer",
                 args: ["{that}", "{sensor}.model.sensorPercentage"]
             },
             updateVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.circleRadius.visualizer.updateVisualization"
+                funcName: "fluid.nexusSensorVisualizer.circleRadius.visualizer.updateVisualization"
             }
         }
     });
 
-    gpii.nexusSensorVisualizer.circleRadius.visualizer.createVisualizer = function (that, initialSensorValue) {
+    fluid.nexusSensorVisualizer.circleRadius.visualizer.createVisualizer = function (that, initialSensorValue) {
         var svg = that.svg,
             height = that.options.svgOptions.height,
             width = that.options.svgOptions.width;
@@ -77,7 +76,7 @@
             });
     };
 
-    gpii.nexusSensorVisualizer.circleRadius.visualizer.updateVisualization = function (visualizer, change) {
+    fluid.nexusSensorVisualizer.circleRadius.visualizer.updateVisualization = function (visualizer, change) {
 
         var height = visualizer.options.svgOptions.height;
 
@@ -93,22 +92,22 @@
         });
     };
 
-    fluid.defaults("gpii.nexusSensorVisualizer.horizontalBar", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.horizontalBar", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             sensor: {
                 options: {
-                    gradeNames: ["gpii.nexusSensorVisualizer.sensorPercentage"]
+                    gradeNames: ["fluid.nexusSensorVisualizer.sensorPercentage"]
                 }
             },
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.horizontalBar.visualizer"
+                type: "fluid.nexusSensorVisualizer.horizontalBar.visualizer"
             }
         }
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizer.horizontalBar.visualizer", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel.fadeInPresenter", "gpii.nexusVisualizerBase"],
+    fluid.defaults("fluid.nexusSensorVisualizer.horizontalBar.visualizer", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel.fadeInPresenter", "fluid.nexusVisualizerBase"],
         selectors: {
             sensorValueIndicator: ".nexus-nexusSensorVisualizationPanel-sensorDisplay-bar"
         },
@@ -118,17 +117,17 @@
         },
         invokers: {
             createVisualizer: {
-                funcName: "gpii.nexusSensorVisualizer.horizontalBar.visualizer.createVisualizer",
+                funcName: "fluid.nexusSensorVisualizer.horizontalBar.visualizer.createVisualizer",
                 args: ["{that}", "{sensor}.model.sensorPercentage"]
             },
             updateVisualizer: {
                 funcName:
-                "gpii.nexusSensorVisualizer.horizontalBar.visualizer.updateVisualization"
+                "fluid.nexusSensorVisualizer.horizontalBar.visualizer.updateVisualization"
             }
         }
     });
 
-    gpii.nexusSensorVisualizer.horizontalBar.visualizer.createVisualizer = function (that, initialValue) {
+    fluid.nexusSensorVisualizer.horizontalBar.visualizer.createVisualizer = function (that, initialValue) {
         var svg = that.svg,
             width = that.options.svgOptions.width,
             height = that.options.svgOptions.height;
@@ -150,7 +149,7 @@
             });
     };
 
-    gpii.nexusSensorVisualizer.horizontalBar.visualizer.updateVisualization = function (visualizer, change) {
+    fluid.nexusSensorVisualizer.horizontalBar.visualizer.updateVisualization = function (visualizer, change) {
         var bar = visualizer.sensorValueIndicator,
             width = visualizer.options.svgOptions.width;
 

--- a/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-temperatureScale.js
+++ b/science-lab/sensor-presentations/js/visualizers/nexusSensorVisualizer-temperatureScale.js
@@ -1,21 +1,20 @@
 (function () {
     "use strict";
 
-    var gpii = fluid.registerNamespace("gpii");
     var d3 = fluid.registerNamespace("d3");
 
     // A specifically formatted heat scale,
-    fluid.defaults("gpii.nexusSensorVisualizer.temperature", {
-        gradeNames: ["gpii.nexusSensorVisualizer.colorScale"],
+    fluid.defaults("fluid.nexusSensorVisualizer.temperature", {
+        gradeNames: ["fluid.nexusSensorVisualizer.colorScale"],
         components: {
             visualizer: {
-                type: "gpii.nexusSensorVisualizer.temperature.visualizer"
+                type: "fluid.nexusSensorVisualizer.temperature.visualizer"
             }
         }
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizer.temperature.visualizer", {
-        gradeNames: ["gpii.nexusSensorVisualizer.colorScale.visualizer"],
+    fluid.defaults("fluid.nexusSensorVisualizer.temperature.visualizer", {
+        gradeNames: ["fluid.nexusSensorVisualizer.colorScale.visualizer"],
         model: {
             svgTitle: "An animated heat scale.",
             svgDescription: "An animated heat scale."
@@ -37,13 +36,13 @@
         },
         invokers: {
             getIndicatorColor: {
-                funcName: "gpii.nexusSensorVisualizer.temperature.visualizer.getIndicatorColor",
+                funcName: "fluid.nexusSensorVisualizer.temperature.visualizer.getIndicatorColor",
                 args: ["{that}", "{arguments}.0"]
             }
         }
     });
 
-    gpii.nexusSensorVisualizer.temperature.visualizer.getIndicatorColor = function(that, indicatorValue) {
+    fluid.nexusSensorVisualizer.temperature.visualizer.getIndicatorColor = function(that, indicatorValue) {
         var thresholdScale = d3.scale.linear().domain([10,25,40]).range(["blue", "white", "red"]);
         return thresholdScale(indicatorValue);
     };

--- a/science-lab/sensor-presentations/sonification/index.html
+++ b/science-lab/sensor-presentations/sonification/index.html
@@ -30,7 +30,7 @@
         <script type="text/javascript" src="../../../../node_modules/flocking/src/ugens/granular.js"></script>
         <script type="text/javascript" src="../../../../node_modules/flocking/src/ugens/distortion.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../../../../node_modules/nexus-science-lab-synths/src/buffer-loader.js"></script>
         <script type="text/javascript" src="../../../../node_modules/nexus-science-lab-synths/src/ph-synth.js"></script>
@@ -50,7 +50,7 @@
             var environment = flock.init();
             environment.start();
 
-            window.nexusSensorSonificationPanel = gpii.nexusSensorSonificationPanel(".nexus-nexusSensorSonificationPanel", {
+            window.nexusSensorSonificationPanel = fluid.nexusSensorSonificationPanel(".nexus-nexusSensorSonificationPanel", {
                 members: {
                     nexusHost: window.location.hostname
                 }

--- a/science-lab/sensor-presentations/sonification/test.html
+++ b/science-lab/sensor-presentations/sonification/test.html
@@ -27,7 +27,7 @@
         <script type="text/javascript" src="../../../../node_modules/flocking/src/ugens/math.js"></script>
         <script type="text/javascript" src="../../../../node_modules/flocking/src/ugens/envelopes.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../js/sensorPlayer.js"></script>
         <script type="text/javascript" src="../js/nexusSensorPresentationPanel.js"></script>
@@ -44,10 +44,10 @@
             var environment = flock.init();
             environment.start();
 
-            var sensorSonifier = gpii.sensorPlayer.sensorSonifier({
+            var sensorSonifier = fluid.sensorPlayer.sensorSonifier({
                     components: {
                         sensorDisplayDebug: {
-                            type: "gpii.sensorPlayer.sensorDisplayDebug",
+                            type: "fluid.sensorPlayer.sensorDisplayDebug",
                             container: ".debugContainer"
                         }
                     }

--- a/science-lab/sensor-presentations/tests/html/nexusSensorPresentationPanel-Tests.html
+++ b/science-lab/sensor-presentations/tests/html/nexusSensorPresentationPanel-Tests.html
@@ -35,7 +35,7 @@
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesMultiDataSet.js"></script>
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesSingleDataSet.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../../js/nexusSensorPresentationPanel.js"></script>
 

--- a/science-lab/sensor-presentations/tests/html/nexusSensorVisualizers-Tests.html
+++ b/science-lab/sensor-presentations/tests/html/nexusSensorVisualizers-Tests.html
@@ -35,7 +35,7 @@
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesMultiDataSet.js"></script>
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesSingleDataSet.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../../js/nexusSensorPresentationPanel.js"></script>
 

--- a/science-lab/sensor-presentations/tests/html/sensorPlayer-Tests.html
+++ b/science-lab/sensor-presentations/tests/html/sensorPlayer-Tests.html
@@ -35,7 +35,7 @@
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesMultiDataSet.js"></script>
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesSingleDataSet.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../../js/nexusSensorPresentationPanel.js"></script>
 

--- a/science-lab/sensor-presentations/tests/js/mocks.js
+++ b/science-lab/sensor-presentations/tests/js/mocks.js
@@ -45,8 +45,8 @@ gpii.nexusWebSocketBoundComponentMock.registerModelListener = function () {
     return;
 };
 
-    fluid.defaults("gpii.nexusSensorPresentationPanelMock", {
-        gradeNames: ["gpii.nexusSensorPresentationPanel", "gpii.nexusWebSocketBoundComponentMock", "fluid.viewComponent"],
+    fluid.defaults("fluid.nexusSensorPresentationPanelMock", {
+        gradeNames: ["fluid.nexusSensorPresentationPanel", "gpii.nexusWebSocketBoundComponentMock", "fluid.viewComponent"],
         // Eases testing, since we don't have to pause to wait for
         // the fade-out animation before testing that the container
         // is removed
@@ -55,16 +55,16 @@ gpii.nexusWebSocketBoundComponentMock.registerModelListener = function () {
         }
     });
 
-    fluid.defaults("gpii.nexusSensorVisualizationPanelMock", {
-        gradeNames: ["gpii.nexusSensorVisualizationPanel", "gpii.nexusSensorPresentationPanelMock"],
+    fluid.defaults("fluid.nexusSensorVisualizationPanelMock", {
+        gradeNames: ["fluid.nexusSensorVisualizationPanel", "fluid.nexusSensorPresentationPanelMock"],
         dynamicComponentContainerOptions: {
             // fluid.stringTemplate
             containerIndividualClassTemplate: "nexus-nexusSensorVisualizationPanel-sensorDisplay-%sensorId"
         }
     });
 
-    fluid.defaults("gpii.nexusSensorSonificationPanelMock", {
-        gradeNames: ["gpii.nexusSensorSonificationPanel", "gpii.nexusSensorPresentationPanelMock"],
+    fluid.defaults("fluid.nexusSensorSonificationPanelMock", {
+        gradeNames: ["fluid.nexusSensorSonificationPanel", "fluid.nexusSensorPresentationPanelMock"],
         dynamicComponentContainerOptions: {
             // fluid.stringTemplate
             containerIndividualClassTemplate: "nexus-nexusSensorSonificationPanel-sensorDisplay-%sensorId"

--- a/science-lab/sensor-presentations/tests/js/nexusSensorPresentationPanelTests.js
+++ b/science-lab/sensor-presentations/tests/js/nexusSensorPresentationPanelTests.js
@@ -4,21 +4,21 @@
 
     "use strict";
 
-    fluid.defaults("gpii.tests.sensorPresentationPanelTests", {
+    fluid.defaults("fluid.tests.sensorPresentationPanelTests", {
         gradeNames: ["fluid.test.testEnvironment"],
         components: {
             sensorPresentationPanelTester: {
-                type: "gpii.tests.sensorPresentationPanelTester"
+                type: "fluid.tests.sensorPresentationPanelTester"
             }
         }
     });
 
-    fluid.defaults("gpii.tests.sensorVisualizationPanelTests", {
-        gradeNames: ["gpii.tests.sensorPresentationPanelTests"],
+    fluid.defaults("fluid.tests.sensorVisualizationPanelTests", {
+        gradeNames: ["fluid.tests.sensorPresentationPanelTests"],
 
         components: {
             sensorPresentationPanel: {
-                type: "gpii.nexusSensorVisualizationPanelMock",
+                type: "fluid.nexusSensorVisualizationPanelMock",
                 container: ".nexus-nexusSensorVisualizationPanel",
                 createOnEvent: "{sensorPresentationPanelTester}.events.onTestCaseStart",
                 options: {
@@ -26,16 +26,16 @@
                 }
             },
             sensorPresentationPanelTester: {
-                type: "gpii.tests.sensorVisualizationPanelTester"
+                type: "fluid.tests.sensorVisualizationPanelTester"
             }
         }
     });
 
-    fluid.defaults("gpii.tests.sensorSonificationPanelTests", {
-        gradeNames: ["gpii.tests.sensorPresentationPanelTests"],
+    fluid.defaults("fluid.tests.sensorSonificationPanelTests", {
+        gradeNames: ["fluid.tests.sensorPresentationPanelTests"],
         components: {
             sensorPresentationPanel: {
-                type: "gpii.nexusSensorSonificationPanelMock",
+                type: "fluid.nexusSensorSonificationPanelMock",
                 container: ".nexus-nexusSensorSonificationPanel",
                 createOnEvent: "{sensorPresentationPanelTester}.events.onTestCaseStart",
                 options: {
@@ -43,12 +43,12 @@
                 }
             },
             sensorPresentationPanelTester: {
-                type: "gpii.tests.sensorSonificationPanelTester"
+                type: "fluid.tests.sensorSonificationPanelTester"
             }
         }
     });
 
-    fluid.defaults("gpii.tests.sensorPresentationPanelTester", {
+    fluid.defaults("fluid.tests.sensorPresentationPanelTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test sensor presentation panel",
@@ -56,11 +56,11 @@
                 name: "Test presentation panel sensor create and remove behaviour",
                 expect: 12,
                 sequence: [{
-                    func: "gpii.tests.sensorPresentationPanelTester.testCreateSensor",
+                    func: "fluid.tests.sensorPresentationPanelTester.testCreateSensor",
                     args: ["{sensorPresentationPanel}"]
                 },
                 {
-                  func: "gpii.tests.sensorPresentationPanelTester.testRemoveSensor",
+                  func: "fluid.tests.sensorPresentationPanelTester.testRemoveSensor",
                   args: ["{sensorPresentationPanel}"]
                 }]
             }]
@@ -71,15 +71,15 @@
                 name: "Test presentation panel sensor ordering",
                 expect: 20,
                 sequence: [{
-                    func: "gpii.tests.sensorPresentationPanelTester.testSensorOrdering",
+                    func: "fluid.tests.sensorPresentationPanelTester.testSensorOrdering",
                     args: ["{sensorPresentationPanel}"]
                 }]
             }]
         }]
     });
 
-    fluid.defaults("gpii.tests.sensorVisualizationPanelTester", {
-        gradeNames: ["gpii.tests.sensorPresentationPanelTester"],
+    fluid.defaults("fluid.tests.sensorVisualizationPanelTester", {
+        gradeNames: ["fluid.tests.sensorPresentationPanelTester"],
         modules: [{
             name: "Test sensor visualization panel"
         },
@@ -88,8 +88,8 @@
         }]
     });
 
-    fluid.defaults("gpii.tests.sensorSonificationPanelTester", {
-        gradeNames: ["gpii.tests.sensorPresentationPanelTester"],
+    fluid.defaults("fluid.tests.sensorSonificationPanelTester", {
+        gradeNames: ["fluid.tests.sensorPresentationPanelTester"],
         modules: [{
             name: "Test sensor sonification panel"
         },
@@ -142,7 +142,7 @@
       }
   };
 
-    gpii.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking = function (sensorPresentationPanel, sensorKey, verifyAbsence) {
+    fluid.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking = function (sensorPresentationPanel, sensorKey, verifyAbsence) {
 
         var verifyFunction = verifyAbsence ? "assertUndefined" : "assertNotUndefined";
 
@@ -151,7 +151,7 @@
         jqUnit[verifyFunction]("attachedSensors object " + verifyText + " " + sensorKey, sensorPresentationPanel.attachedSensors[sensorKey]);
     };
 
-    gpii.tests.sensorPresentationPanelTester.verifySensorContainer = function(sensorPresentationPanel, sensorvisualizerClass, verifyAbsence) {
+    fluid.tests.sensorPresentationPanelTester.verifySensorContainer = function(sensorPresentationPanel, sensorvisualizerClass, verifyAbsence) {
 
         var verifyLength = verifyAbsence ? 0 : 1;
 
@@ -162,51 +162,51 @@
         jqUnit.assertTrue("Container with class " + sensorvisualizerClass + " " + verifyText, sensorContainer.length === verifyLength);
     };
 
-    gpii.tests.sensorPresentationPanelTester.verifySensorPresenterCreation = function (sensorPresentationPanel, sensorKey, expectedAttachedContainersLength) {
+    fluid.tests.sensorPresentationPanelTester.verifySensorPresenterCreation = function (sensorPresentationPanel, sensorKey, expectedAttachedContainersLength) {
 
         var containerClassKey = sensorPresentationPanel.options.containerClassKey;
 
-        gpii.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking(sensorPresentationPanel, sensorKey);
+        fluid.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking(sensorPresentationPanel, sensorKey);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorContainer(sensorPresentationPanel, "." + fakeSensors[sensorKey][containerClassKey]);
+        fluid.tests.sensorPresentationPanelTester.verifySensorContainer(sensorPresentationPanel, "." + fakeSensors[sensorKey][containerClassKey]);
 
         jqUnit.assertTrue("attachedContainers array is at expected length of " + expectedAttachedContainersLength, sensorPresentationPanel.attachedContainers.length === expectedAttachedContainersLength);
     };
 
-    gpii.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval = function (sensorPresentationPanel, sensorKey, expectedAttachedContainersLength) {
+    fluid.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval = function (sensorPresentationPanel, sensorKey, expectedAttachedContainersLength) {
 
         var containerClassKey = sensorPresentationPanel.options.containerClassKey;
 
-        gpii.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking(sensorPresentationPanel, sensorKey, true);
+        fluid.tests.sensorPresentationPanelTester.verifyAttachedSensorTracking(sensorPresentationPanel, sensorKey, true);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorContainer(sensorPresentationPanel, "." + fakeSensors[sensorKey][containerClassKey], true);
+        fluid.tests.sensorPresentationPanelTester.verifySensorContainer(sensorPresentationPanel, "." + fakeSensors[sensorKey][containerClassKey], true);
 
         jqUnit.assertTrue("attachedContainers array is at expected length of " + expectedAttachedContainersLength, sensorPresentationPanel.attachedContainers.length === expectedAttachedContainersLength);
     };
 
-    gpii.tests.sensorPresentationPanelTester.testCreateSensor = function (sensorPresentationPanel) {
+    fluid.tests.sensorPresentationPanelTester.testCreateSensor = function (sensorPresentationPanel) {
 
         // Add a first sensor
         sensorPresentationPanel.applier.change("sensors.fakeSensorPH",
         fakeSensors.fakeSensorPH);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorPresenterCreation(sensorPresentationPanel, "fakeSensorPH", 1);
+        fluid.tests.sensorPresentationPanelTester.verifySensorPresenterCreation(sensorPresentationPanel, "fakeSensorPH", 1);
 
         // Add a second sensor
         sensorPresentationPanel.applier.change("sensors.fakeSensorTemperature",
         fakeSensors.fakeSensorTemperature);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorPresenterCreation(sensorPresentationPanel, "fakeSensorTemperature", 2);
+        fluid.tests.sensorPresentationPanelTester.verifySensorPresenterCreation(sensorPresentationPanel, "fakeSensorTemperature", 2);
     };
 
-    gpii.tests.sensorPresentationPanelTester.testRemoveSensor = function (sensorPresentationPanel) {
+    fluid.tests.sensorPresentationPanelTester.testRemoveSensor = function (sensorPresentationPanel) {
         sensorPresentationPanel.applier.change("sensors.fakeSensorPH", null, "DELETE");
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval(sensorPresentationPanel, "fakeSensorPH", 1);
+        fluid.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval(sensorPresentationPanel, "fakeSensorPH", 1);
 
         sensorPresentationPanel.applier.change("sensors.fakeSensorTemperature", null, "DELETE");
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval(sensorPresentationPanel, "fakeSensorTemperature", 0);
+        fluid.tests.sensorPresentationPanelTester.verifySensorPresenterRemoval(sensorPresentationPanel, "fakeSensorTemperature", 0);
     };
 
     var sensorOrderSpecs = {
@@ -228,7 +228,7 @@
         ]
     };
 
-    gpii.tests.sensorPresentationPanelTester.verifySensorOrdering = function (sensorPresentationPanel, sensorOrderSpec) {
+    fluid.tests.sensorPresentationPanelTester.verifySensorOrdering = function (sensorPresentationPanel, sensorOrderSpec) {
 
         var containerClassKey = sensorPresentationPanel.options.containerClassKey;
 
@@ -245,31 +245,31 @@
         });
     };
 
-    gpii.tests.sensorPresentationPanelTester.testSensorOrdering = function (sensorPresentationPanel) {
+    fluid.tests.sensorPresentationPanelTester.testSensorOrdering = function (sensorPresentationPanel) {
 
         sensorPresentationPanel.applier.change("sensors.fakeSensorBeta",
         fakeSensors.fakeSensorBeta);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.betaFirst);
+        fluid.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.betaFirst);
 
         sensorPresentationPanel.applier.change("sensors.fakeSensorAlpha",
         fakeSensors.fakeSensorAlpha);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstBetaSecond);
+        fluid.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstBetaSecond);
 
         sensorPresentationPanel.applier.change("sensors.fakeSensorGamma",
         fakeSensors.fakeSensorGamma);
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstBetaSecondGammaThird);
+        fluid.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstBetaSecondGammaThird);
 
         sensorPresentationPanel.applier.change("sensors.fakeSensorBeta",
         null, "DELETE");
 
-        gpii.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstGammaSecond);
+        fluid.tests.sensorPresentationPanelTester.verifySensorOrdering(sensorPresentationPanel, sensorOrderSpecs.alphaFirstGammaSecond);
     };
 
-    gpii.tests.sensorVisualizationPanelTests();
+    fluid.tests.sensorVisualizationPanelTests();
 
-    gpii.tests.sensorSonificationPanelTests();
+    fluid.tests.sensorSonificationPanelTests();
 
 }());

--- a/science-lab/sensor-presentations/tests/js/nexusSensorVisualizersTests.js
+++ b/science-lab/sensor-presentations/tests/js/nexusSensorVisualizersTests.js
@@ -4,23 +4,23 @@
 
     "use strict";
 
-    fluid.defaults("gpii.tests.visualizerTestsBase", {
+    fluid.defaults("fluid.tests.visualizerTestsBase", {
         gradeNames: ["fluid.test.testEnvironment"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.visualizerTester"
+                type: "fluid.tests.visualizerTester"
             },
             sensorVisualizer: {
                 createOnEvent: "{visualizerTester}.events.onTestCaseStart",
                 options: {
-                    gradeNames: ["gpii.tests.testVisualizerBase"]
+                    gradeNames: ["fluid.tests.testVisualizerBase"]
                 }
             }
         }
     });
 
-    fluid.defaults("gpii.tests.testVisualizerBase", {
-        gradeNames: ["gpii.nexusSensorVisualizerBase"],
+    fluid.defaults("fluid.tests.testVisualizerBase", {
+        gradeNames: ["fluid.nexusSensorVisualizerBase"],
         components: {
             sensor: {
                 type: "fluid.modelComponent",
@@ -46,7 +46,7 @@
         }
     });
 
-    gpii.tests.generateVisualizerIndicatorTestSequence = function(testSpec) {
+    fluid.tests.generateVisualizerIndicatorTestSequence = function(testSpec) {
         var sequence = [];
 
         fluid.each(testSpec.sequence, function (sequenceItem) {
@@ -57,7 +57,7 @@
 
             var listener = {
                 event: "{sensorVisualizer}.visualizer.events.onUpdateCompleted",
-                listener: "gpii.tests.verifyIndicator",
+                listener: "fluid.tests.verifyIndicator",
                 args: ["{sensorVisualizer}.visualizer.dom.sensorValueIndicator", testSpec.checkAttribute, sequenceItem.attributeValue]
             };
 
@@ -66,14 +66,14 @@
         return sequence;
     };
 
-    fluid.defaults("gpii.tests.realTimeVisualizerTests", {
-        gradeNames: ["gpii.tests.visualizerTestsBase"],
+    fluid.defaults("fluid.tests.realTimeVisualizerTests", {
+        gradeNames: ["fluid.tests.visualizerTestsBase"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.realTimeVisualizerTester"
+                type: "fluid.tests.realTimeVisualizerTester"
             },
             sensorVisualizer: {
-                type: "gpii.nexusSensorVisualizer.realTimeScale",
+                type: "fluid.nexusSensorVisualizer.realTimeScale",
                 options: {
                     components: {
                         visualizer: {
@@ -85,7 +85,7 @@
         }
     });
 
-    gpii.tests.realTimeVisualizerTestSequence = {
+    fluid.tests.realTimeVisualizerTestSequence = {
             checkAttribute: "height",
             // Left: sensor value change (num)
             // Right: expected corresponding change to
@@ -110,26 +110,26 @@
             ]
     };
 
-    fluid.defaults("gpii.tests.realTimeVisualizerTester", {
+    fluid.defaults("fluid.tests.realTimeVisualizerTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test real-time visualizer",
             tests: [{
                 name: "Test indicator response to sensor model changes",
                 expect: 4,
-                sequence: gpii.tests.generateVisualizerIndicatorTestSequence(gpii.tests.realTimeVisualizerTestSequence)
+                sequence: fluid.tests.generateVisualizerIndicatorTestSequence(fluid.tests.realTimeVisualizerTestSequence)
             }]
         }]
     });
 
-    fluid.defaults("gpii.tests.circularPercentageScaleVisualizerTests", {
-        gradeNames: ["gpii.tests.visualizerTestsBase"],
+    fluid.defaults("fluid.tests.circularPercentageScaleVisualizerTests", {
+        gradeNames: ["fluid.tests.visualizerTestsBase"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.circularPercentageScaleVisualizerTester"
+                type: "fluid.tests.circularPercentageScaleVisualizerTester"
             },
             sensorVisualizer: {
-                type: "gpii.nexusSensorVisualizer.circleRadius",
+                type: "fluid.nexusSensorVisualizer.circleRadius",
                 options: {
                     components: {
                         visualizer: {
@@ -141,7 +141,7 @@
         }
     });
 
-    gpii.tests.circularPercentageScaleVisualizerTestSequence = {
+    fluid.tests.circularPercentageScaleVisualizerTestSequence = {
             checkAttribute: "r",
             sequence: [
                 {
@@ -163,26 +163,26 @@
             ]
     };
 
-    fluid.defaults("gpii.tests.circularPercentageScaleVisualizerTester", {
+    fluid.defaults("fluid.tests.circularPercentageScaleVisualizerTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test circular percentage scale visualizer",
             tests: [{
                 name: "Test indicator response to sensor model changes",
                 expect: 4,
-                sequence: gpii.tests.generateVisualizerIndicatorTestSequence(gpii.tests.circularPercentageScaleVisualizerTestSequence)
+                sequence: fluid.tests.generateVisualizerIndicatorTestSequence(fluid.tests.circularPercentageScaleVisualizerTestSequence)
             }]
         }]
     });
 
-    fluid.defaults("gpii.tests.horizontalBarPercentageScaleVisualizerTests", {
-        gradeNames: ["gpii.tests.visualizerTestsBase"],
+    fluid.defaults("fluid.tests.horizontalBarPercentageScaleVisualizerTests", {
+        gradeNames: ["fluid.tests.visualizerTestsBase"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.horizontalBarPercentageScaleVisualizerTester"
+                type: "fluid.tests.horizontalBarPercentageScaleVisualizerTester"
             },
             sensorVisualizer: {
-                type: "gpii.nexusSensorVisualizer.horizontalBar",
+                type: "fluid.nexusSensorVisualizer.horizontalBar",
                 options: {
                     components: {
                         visualizer: {
@@ -194,7 +194,7 @@
         }
     });
 
-    gpii.tests.horizontalBarPercentageScaleVisualizerTestSequence = {
+    fluid.tests.horizontalBarPercentageScaleVisualizerTestSequence = {
             checkAttribute: "width",
             sequence: [
                 {
@@ -216,26 +216,26 @@
             ]
     };
 
-    fluid.defaults("gpii.tests.horizontalBarPercentageScaleVisualizerTester", {
+    fluid.defaults("fluid.tests.horizontalBarPercentageScaleVisualizerTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test horizontal bar percentage scale visualizer",
             tests: [{
                 name: "Test indicator response to sensor model changes",
                 expect: 4,
-                sequence: gpii.tests.generateVisualizerIndicatorTestSequence(gpii.tests.horizontalBarPercentageScaleVisualizerTestSequence)
+                sequence: fluid.tests.generateVisualizerIndicatorTestSequence(fluid.tests.horizontalBarPercentageScaleVisualizerTestSequence)
             }]
         }]
     });
 
-    fluid.defaults("gpii.tests.colorScaleVisualizerTests", {
-        gradeNames: ["gpii.tests.visualizerTestsBase"],
+    fluid.defaults("fluid.tests.colorScaleVisualizerTests", {
+        gradeNames: ["fluid.tests.visualizerTestsBase"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.colorScaleVisualizerTester"
+                type: "fluid.tests.colorScaleVisualizerTester"
             },
             sensorVisualizer: {
-                type: "gpii.nexusSensorVisualizer.colorScale",
+                type: "fluid.nexusSensorVisualizer.colorScale",
                 options: {
                     components: {
                         visualizer: {
@@ -260,7 +260,7 @@
         }
     });
 
-    gpii.tests.colorScaleVisualizerTestSequence = {
+    fluid.tests.colorScaleVisualizerTestSequence = {
             checkAttribute: "transform",
             sequence: [
                 {
@@ -283,7 +283,7 @@
     };
 
 
-    gpii.tests.expectedColorBarLabelValues = [
+    fluid.tests.expectedColorBarLabelValues = [
         {
             text: "0.00 – 33.33",
             y: "406.6666666666667"
@@ -298,7 +298,7 @@
         }
     ];
 
-    gpii.tests.expectedColorBarPositionedValues = [
+    fluid.tests.expectedColorBarPositionedValues = [
         {
             text: "0",
             y: "480"
@@ -313,20 +313,20 @@
         }
     ];
 
-    fluid.defaults("gpii.tests.colorScaleVisualizerTester", {
+    fluid.defaults("fluid.tests.colorScaleVisualizerTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test color scale visualizer",
             tests: [{
                 name: "Test indicator response to sensor model changes",
                 expect: 4,
-                sequence: gpii.tests.generateVisualizerIndicatorTestSequence(gpii.tests.colorScaleVisualizerTestSequence)
+                sequence: fluid.tests.generateVisualizerIndicatorTestSequence(fluid.tests.colorScaleVisualizerTestSequence)
             },{
                 name: "Test color scale generation",
                 expect: 3,
                 sequence: [
                     {
-                        func: "gpii.tests.verifyColorScaleGeneration",
+                        func: "fluid.tests.verifyColorScaleGeneration",
                         args: ["{sensorVisualizer}"]
                     }
                 ]
@@ -340,7 +340,7 @@
                         args: ["sensorValue", 55]
                     },
                     {
-                        listener: "gpii.tests.verifyIndicatorColor",
+                        listener: "fluid.tests.verifyIndicatorColor",
                         event: "{sensorVisualizer}.visualizer.events.onUpdateCompleted",
                         args: ["{sensorVisualizer}", "#00FF00"]
                     },
@@ -349,7 +349,7 @@
                         args: ["sensorValue", 25]
                     },
                     {
-                        listener: "gpii.tests.verifyIndicatorColor",
+                        listener: "fluid.tests.verifyIndicatorColor",
                         event: "{sensorVisualizer}.visualizer.events.onUpdateCompleted",
                         args: ["{sensorVisualizer}", "#FF0000"]
                     },
@@ -358,7 +358,7 @@
                         args: ["sensorValue", 75]
                     },
                     {
-                        listener: "gpii.tests.verifyIndicatorColor",
+                        listener: "fluid.tests.verifyIndicatorColor",
                         event: "{sensorVisualizer}.visualizer.events.onUpdateCompleted",
                         args: ["{sensorVisualizer}", "#0000FF"]
                     }
@@ -368,12 +368,12 @@
                 expect: 12,
                 sequence: [
                     {
-                        func: "gpii.tests.verifyColorBarLabels",
-                        args: ["{sensorVisualizer}", "colorBarLabels", gpii.tests.expectedColorBarLabelValues]
+                        func: "fluid.tests.verifyColorBarLabels",
+                        args: ["{sensorVisualizer}", "colorBarLabels", fluid.tests.expectedColorBarLabelValues]
                     },
                     {
-                        func: "gpii.tests.verifyColorBarLabels",
-                        args: ["{sensorVisualizer}", "positionedText", gpii.tests.expectedColorBarPositionedValues]
+                        func: "fluid.tests.verifyColorBarLabels",
+                        args: ["{sensorVisualizer}", "positionedText", fluid.tests.expectedColorBarPositionedValues]
                     }
                 ]
             }
@@ -381,7 +381,7 @@
         }]
     });
 
-    gpii.tests.verifyColorBarLabels = function (sensorVisualizer, labelSelector, expectedValues) {
+    fluid.tests.verifyColorBarLabels = function (sensorVisualizer, labelSelector, expectedValues) {
 
         var barLabels = sensorVisualizer.visualizer.locate(labelSelector);
         fluid.each(barLabels, function (barLabel, idx) {
@@ -397,13 +397,13 @@
         });
     };
 
-    gpii.tests.verifyIndicatorColor = function (sensorVisualizer, expectedColor) {
+    fluid.tests.verifyIndicatorColor = function (sensorVisualizer, expectedColor) {
         var indicator = sensorVisualizer.visualizer.locate("sensorValueIndicator");
 
         jqUnit.assertEquals("Indicator fill color is expected value of " + expectedColor, expectedColor.toLowerCase(), indicator.attr("fill").toLowerCase());
     };
 
-    gpii.tests.verifyColorScaleGeneration = function (sensorVisualizer) {
+    fluid.tests.verifyColorScaleGeneration = function (sensorVisualizer) {
         var colors = sensorVisualizer.visualizer.options.scaleOptions.colors;
         // ["#FF0000", "#00FF00", "#0000FF"]
         var colorBars = sensorVisualizer.visualizer.locate("colorBars");
@@ -416,14 +416,14 @@
 
     };
 
-    fluid.defaults("gpii.tests.lineChartVisualizerTests", {
-        gradeNames: ["gpii.tests.visualizerTestsBase"],
+    fluid.defaults("fluid.tests.lineChartVisualizerTests", {
+        gradeNames: ["fluid.tests.visualizerTestsBase"],
         components: {
             visualizerTester: {
-                type: "gpii.tests.lineChartVisualizerTester"
+                type: "fluid.tests.lineChartVisualizerTester"
             },
             sensorVisualizer: {
-                type: "gpii.nexusSensorVisualizer.lineChart",
+                type: "fluid.nexusSensorVisualizer.lineChart",
                 options: {
                     components: {
                         visualizer: {
@@ -445,7 +445,7 @@
     // First value is 50, it should get popped
     // off after the final change because the
     // maxValuesRetained is set to 5
-    gpii.tests.lineChartAccumulatorExpectedValues = [
+    fluid.tests.lineChartAccumulatorExpectedValues = [
             [50, 25],
             [50, 25, 35],
             [50, 25, 35, 45],
@@ -453,7 +453,7 @@
             [25, 35, 45, 55, 65]
     ];
 
-    fluid.defaults("gpii.tests.lineChartVisualizerTester", {
+    fluid.defaults("fluid.tests.lineChartVisualizerTester", {
         gradeNames: ["fluid.test.testCaseHolder"],
         modules: [{
             name: "Test line chart visualizer",
@@ -466,62 +466,62 @@
                         args: ["sensorValue", 25]
                     },
                     {
-                        func: "gpii.tests.verifyLineChartSensorValueAccumulation",
-                        args: ["{sensorVisualizer}.sensorValueAccumulator", gpii.tests.lineChartAccumulatorExpectedValues[0]]
+                        func: "fluid.tests.verifyLineChartSensorValueAccumulation",
+                        args: ["{sensorVisualizer}.sensorValueAccumulator", fluid.tests.lineChartAccumulatorExpectedValues[0]]
                     },
                     {
                         func: "{sensorVisualizer}.sensor.applier.change",
                         args: ["sensorValue", 35]
                     },
                     {
-                        func: "gpii.tests.verifyLineChartSensorValueAccumulation",
-                        args: ["{sensorVisualizer}.sensorValueAccumulator", gpii.tests.lineChartAccumulatorExpectedValues[1]]
+                        func: "fluid.tests.verifyLineChartSensorValueAccumulation",
+                        args: ["{sensorVisualizer}.sensorValueAccumulator", fluid.tests.lineChartAccumulatorExpectedValues[1]]
                     },
                     {
                         func: "{sensorVisualizer}.sensor.applier.change",
                         args: ["sensorValue", 45]
                     },
                     {
-                        func: "gpii.tests.verifyLineChartSensorValueAccumulation",
-                        args: ["{sensorVisualizer}.sensorValueAccumulator", gpii.tests.lineChartAccumulatorExpectedValues[2]]
+                        func: "fluid.tests.verifyLineChartSensorValueAccumulation",
+                        args: ["{sensorVisualizer}.sensorValueAccumulator", fluid.tests.lineChartAccumulatorExpectedValues[2]]
                     },
                     {
                         func: "{sensorVisualizer}.sensor.applier.change",
                         args: ["sensorValue", 55]
                     },
                     {
-                        func: "gpii.tests.verifyLineChartSensorValueAccumulation",
-                        args: ["{sensorVisualizer}.sensorValueAccumulator", gpii.tests.lineChartAccumulatorExpectedValues[3]]
+                        func: "fluid.tests.verifyLineChartSensorValueAccumulation",
+                        args: ["{sensorVisualizer}.sensorValueAccumulator", fluid.tests.lineChartAccumulatorExpectedValues[3]]
                     },
                     {
                         func: "{sensorVisualizer}.sensor.applier.change",
                         args: ["sensorValue", 65]
                     },
                     {
-                        func: "gpii.tests.verifyLineChartSensorValueAccumulation",
-                        args: ["{sensorVisualizer}.sensorValueAccumulator", gpii.tests.lineChartAccumulatorExpectedValues[4]]
+                        func: "fluid.tests.verifyLineChartSensorValueAccumulation",
+                        args: ["{sensorVisualizer}.sensorValueAccumulator", fluid.tests.lineChartAccumulatorExpectedValues[4]]
                     }
                 ]
             }]
         }]
     });
 
-    gpii.tests.verifyLineChartSensorValueAccumulation = function(accumulator, expected) {
+    fluid.tests.verifyLineChartSensorValueAccumulation = function(accumulator, expected) {
         fluid.each(expected, function (expectedValue, idx) {
             var message = fluid.stringTemplate("Accumulator value at position %idx is expected value of %value", {idx: idx, value: accumulator.model.sensorValues[idx].value});
             jqUnit.assertEquals(message, expectedValue, accumulator.model.sensorValues[idx].value);
         });
     };
 
-    gpii.tests.verifyIndicator = function (indicator, checkAttribute, expectedValue) {
+    fluid.tests.verifyIndicator = function (indicator, checkAttribute, expectedValue) {
         var message = fluid.stringTemplate("Attribute '%checkAttribute' is expected value of %expectedValue", {checkAttribute: checkAttribute, expectedValue: expectedValue});
         jqUnit.assertEquals(message, expectedValue, indicator.attr(checkAttribute));
     };
 
-    gpii.tests.realTimeVisualizerTests();
-    gpii.tests.circularPercentageScaleVisualizerTests();
-    gpii.tests.horizontalBarPercentageScaleVisualizerTests();
-    gpii.tests.colorScaleVisualizerTests();
-    gpii.tests.lineChartVisualizerTests();
+    fluid.tests.realTimeVisualizerTests();
+    fluid.tests.circularPercentageScaleVisualizerTests();
+    fluid.tests.horizontalBarPercentageScaleVisualizerTests();
+    fluid.tests.colorScaleVisualizerTests();
+    fluid.tests.lineChartVisualizerTests();
 
 }());

--- a/science-lab/sensor-presentations/tests/js/sensorPlayerTests.js
+++ b/science-lab/sensor-presentations/tests/js/sensorPlayerTests.js
@@ -13,8 +13,8 @@
             outputScaleMax: 680,
             outputScaleMin: 200,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 440,
-                "gpii.sensorPlayer.transforms.polarityScale": 200
+                "fluid.sensorPlayer.transforms.minMaxScale": 440,
+                "fluid.sensorPlayer.transforms.polarityScale": 200
             }
         },
         {
@@ -25,8 +25,8 @@
             outputScaleMax: 680,
             outputScaleMin: 200,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 680,
-                "gpii.sensorPlayer.transforms.polarityScale": 680
+                "fluid.sensorPlayer.transforms.minMaxScale": 680,
+                "fluid.sensorPlayer.transforms.polarityScale": 680
             }
         },
         {
@@ -37,8 +37,8 @@
             outputScaleMax: 680,
             outputScaleMin: 200,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 200,
-                "gpii.sensorPlayer.transforms.polarityScale": 680
+                "fluid.sensorPlayer.transforms.minMaxScale": 200,
+                "fluid.sensorPlayer.transforms.polarityScale": 680
             }
         },
         {
@@ -49,8 +49,8 @@
             outputScaleMax: 680,
             outputScaleMin: 200,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 680,
-                "gpii.sensorPlayer.transforms.polarityScale": 680
+                "fluid.sensorPlayer.transforms.minMaxScale": 680,
+                "fluid.sensorPlayer.transforms.polarityScale": 680
             }
         },
         {
@@ -61,8 +61,8 @@
             outputScaleMax: 680,
             outputScaleMin: 200,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 200,
-                "gpii.sensorPlayer.transforms.polarityScale": 680
+                "fluid.sensorPlayer.transforms.minMaxScale": 200,
+                "fluid.sensorPlayer.transforms.polarityScale": 680
             }
         },
         {
@@ -73,8 +73,8 @@
             outputScaleMax: 100,
             outputScaleMin: -100,
             expectedOutputValues: {
-                "gpii.sensorPlayer.transforms.minMaxScale": 0,
-                "gpii.sensorPlayer.transforms.polarityScale": -100
+                "fluid.sensorPlayer.transforms.minMaxScale": 0,
+                "fluid.sensorPlayer.transforms.polarityScale": -100
             }
         }
     ];
@@ -115,8 +115,8 @@
         });
     };
 
-    testTransforms("gpii.sensorPlayer.transforms.minMaxScale", transformTestSpecs);
+    testTransforms("fluid.sensorPlayer.transforms.minMaxScale", transformTestSpecs);
 
-    testTransforms("gpii.sensorPlayer.transforms.polarityScale", transformTestSpecs);
+    testTransforms("fluid.sensorPlayer.transforms.polarityScale", transformTestSpecs);
 
 }());

--- a/science-lab/sensor-presentations/visualization/index.html
+++ b/science-lab/sensor-presentations/visualization/index.html
@@ -37,7 +37,7 @@
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesMultiDataSet.js"></script>
         <script src="../../../../node_modules/chartAuthoring/src/js/lineChartTimeSeriesSingleDataSet.js"></script>
 
-        <script type="text/javascript" src="../../../../node_modules/gpii-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
+        <script type="text/javascript" src="../../../../node_modules/infusion-nexus-client/src/NexusWebSocketBoundComponent.js"></script>
 
         <script type="text/javascript" src="../js/sensorPlayer.js"></script>
         <script type="text/javascript" src="../js/nexusSensorPresentationPanel.js"></script>
@@ -57,7 +57,7 @@
         </div>
 
         <script>
-        window.nexusSensorVisualizationPanel = gpii.nexusSensorVisualizationPanel(".nexus-nexusSensorVisualizationPanel", {
+        window.nexusSensorVisualizationPanel = fluid.nexusSensorVisualizationPanel(".nexus-nexusSensorVisualizationPanel", {
             members: {
                 nexusHost: window.location.hostname
             }

--- a/temperature-sensing/TemperatureSensing.json
+++ b/temperature-sensing/TemperatureSensing.json
@@ -1,6 +1,6 @@
 {
     "defaults": {
-        "gpii.nexus.rpiSenseHatDriver.tempSensor1": {
+        "fluid.nexus.rpiSenseHatDriver.tempSensor1": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -8,7 +8,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.rpiSenseHatDriver.tempSensor2": {
+        "fluid.nexus.rpiSenseHatDriver.tempSensor2": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -16,7 +16,7 @@
                 "sensorData": {}
             }
         },
-        "gpii.nexus.scienceLab.collector": {
+        "fluid.nexus.scienceLab.collector": {
             "gradeNames": [
                 "fluid.modelComponent"
             ],
@@ -24,9 +24,9 @@
                 "sensors": {}
             }
         },
-        "gpii.nexus.scienceLab.sendRpiTempSensor1": {
+        "fluid.nexus.scienceLab.sendRpiTempSensor1": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "tempSensor": null,
@@ -57,9 +57,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.sendRpiTempSensor2": {
+        "fluid.nexus.scienceLab.sendRpiTempSensor2": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "tempSensor": null,
@@ -90,9 +90,9 @@
                 }
             }
         },
-        "gpii.nexus.scienceLab.calculateTempDiff": {
+        "fluid.nexus.scienceLab.calculateTempDiff": {
             "gradeNames": [
-                "gpii.nexus.recipeProduct"
+                "fluid.nexus.recipeProduct"
             ],
             "componentPaths": {
                 "tempSensor1": null,
@@ -188,80 +188,80 @@
     },
     "components": {
         "scienceLabCollector": {
-            "type": "gpii.nexus.scienceLab.collector"
+            "type": "fluid.nexus.scienceLab.collector"
         },
         "recipes.sendRpiTempSensor1": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "tempSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor1"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor1"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendRpiTempSensor1",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendRpiTempSensor1"
+                    "type": "fluid.nexus.scienceLab.sendRpiTempSensor1"
                 }
             }
         },
         "recipes.sendRpiTempSensor2": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "tempSensor": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor2"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor2"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "sendRpiTempSensor2",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.sendRpiTempSensor2"
+                    "type": "fluid.nexus.scienceLab.sendRpiTempSensor2"
                 }
             }
         },
         "recipes.calculateTempDiff": {
-            "type": "gpii.nexus.recipe",
+            "type": "fluid.nexus.recipe",
             "reactants": {
                 "tempSensor1": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor1"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor1"
                     }
                 },
                 "tempSensor2": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.rpiSenseHatDriver.tempSensor2"
+                        "gradeName": "fluid.nexus.rpiSenseHatDriver.tempSensor2"
                     }
                 },
                 "collector": {
                     "match": {
                         "type": "gradeMatcher",
-                        "gradeName": "gpii.nexus.scienceLab.collector"
+                        "gradeName": "fluid.nexus.scienceLab.collector"
                     }
                 }
             },
             "product": {
                 "path": "calculateTempDiff",
                 "options": {
-                    "type": "gpii.nexus.scienceLab.calculateTempDiff"
+                    "type": "fluid.nexus.scienceLab.calculateTempDiff"
                 }
             }
         }


### PR DESCRIPTION
This pull request depends on `infusion-nexus-client` prior to the changes to that repository to update the JavaScript names to `fluid.nexus...` (the pull request for that repo hasn't been merged yet). So there are still some references to `gpii` in `infusion-nexus-demos`.

Once the pull request to update `infusion-nexus-client` has been merged, we can update the Demos:

https://github.com/fluid-project/infusion-nexus-client/pull/1
